### PR TITLE
feat: Make Weather API integration optional

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,10 +11,12 @@
 # --------------------------------------
 
 # AccuWeather API Key for weather data
+# OPTIONAL: Weather integration can be disabled in configuration
 # Obtain from: https://developer.accuweather.com/
 WEATHER_API_KEY=YOUR_ACCUWEATHER_API_KEY_HERE
 
 # AccuWeather Location Key for your city
+# OPTIONAL: Weather integration can be disabled in configuration
 # Find your location key: https://developer.accuweather.com/accuweather-locations-api/apis
 LOCATION_KEY=YOUR_ACCUWEATHER_LOCATION_KEY_HERE
 

--- a/configurator-ui/src/components/ProfileEditor.svelte
+++ b/configurator-ui/src/components/ProfileEditor.svelte
@@ -30,6 +30,17 @@
     };
   }
   
+  // Update weather config
+  function updateWeatherField(field, value) {
+    $userConfig = {
+      ...$userConfig,
+      weather: {
+        ...$userConfig.weather,
+        [field]: value
+      }
+    };
+  }
+  
   // Validate GitHub username
   $: formErrors.GITHUB_USERNAME = !isValidUsername($userConfig.profile.GITHUB_USERNAME);
   
@@ -213,6 +224,34 @@
       {#if formErrors.workStartDate}
         <p class="mt-2 text-sm text-red-600">Please enter a valid date</p>
       {/if}
+    </div>
+
+    <!-- Integration Settings Section -->
+    <div class="p-3 border border-gray-200 rounded-md bg-white">
+      <h3 class="text-sm font-medium text-gray-700 mb-3">Integration Settings</h3>
+      
+      <!-- Weather Integration Toggle -->
+      <div class="mb-3">
+        <label class="flex items-center">
+          <input 
+            type="checkbox" 
+            checked={$userConfig.weather?.enabled || false}
+            on:change={(e) => updateWeatherField('enabled', e.target.checked)}
+            class="h-4 w-4 text-primary focus:ring-primary border-gray-300 rounded"
+          />
+          <span class="ml-2 text-sm font-medium text-gray-700">
+            Enable Weather Integration
+            <HelpIconTooltip text="When enabled, ProfileChatter will fetch current weather data from AccuWeather API. Requires WEATHER_API_KEY and LOCATION_KEY environment variables. When disabled, default weather values will be used." />
+          </span>
+        </label>
+        <p class="mt-1 text-xs text-gray-500">
+          {#if $userConfig.weather?.enabled}
+            Weather data will be fetched from AccuWeather API (requires API keys)
+          {:else}
+            Default weather values will be used
+          {/if}
+        </p>
+      </div>
     </div>
     
     <!-- Social Profiles Section -->

--- a/configurator-ui/src/stores/configStore.js
+++ b/configurator-ui/src/stores/configStore.js
@@ -240,6 +240,11 @@ const initialAvatarsConfig = {
   shape: "circle",
 };
 
+// Initial weather configuration
+const initialWeatherConfig = {
+  enabled: true
+};
+
 // Initial placeholder data
 const initialPlaceholderData = [
   // Profile Info category
@@ -558,6 +563,7 @@ export const userConfig = writable({
   profile: structuredClone(initialProfileConfig),
   activeTheme: "ios",
   avatars: structuredClone(initialAvatarsConfig),
+  weather: structuredClone(initialWeatherConfig),
   layout: { 
     ANIMATION: { 
       SCROLL_SPEED_MULTIPLIER: 1.0 
@@ -677,6 +683,7 @@ export function getPreviewConfiguration() {
     },
     activeTheme: currentConfig.activeTheme,
     avatars: currentConfig.avatars,
+    weather: currentConfig.weather,
     chatMessages: currentMessages,
     themeOverrides: currentTheme,
     layoutAnimationOverrides: {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -19,6 +19,10 @@ export const config = {
     yOffsetPx: 0
   },
 
+  weather: {
+    enabled: true
+  },
+
   themes: {
     ios: {
       ME_BUBBLE_COLOR: '#0B93F6',

--- a/src/services/data_sources/weatherDataSource.js
+++ b/src/services/data_sources/weatherDataSource.js
@@ -54,6 +54,12 @@ function getWeatherEmoji(weatherText) {
  */
 async function getWeatherData() {
   try {
+    // Check if weather integration is disabled via configuration
+    if (!config.weather.enabled) {
+      console.info('Weather data fetching is disabled via configuration.');
+      return {};
+    }
+
     // Check if valid cached data exists
     if (weatherCache.data && Date.now() < weatherCache.expiresAt) {
       console.info('Using cached weather data.');
@@ -65,7 +71,8 @@ async function getWeatherData() {
     const locationKey = process.env.LOCATION_KEY;
     
     if (!apiKey || !locationKey) {
-      throw new Error("Weather API key or location key not provided in environment variables.");
+      console.info('Weather API key or location key not provided, skipping weather fetch.');
+      return {};
     }
     
     // For browser environments

--- a/src/utils/ConfigValidator.js
+++ b/src/utils/ConfigValidator.js
@@ -144,6 +144,13 @@ function validateAvatarsConfig(avatarsConfig, pathPrefix = 'config.avatars') {
   return isValid;
 }
 
+function validateWeatherConfig(weatherConfig, pathPrefix = 'config.weather') {
+  if (!validateObjectWithProps(weatherConfig, pathPrefix, ['enabled'])) return false;
+  let isValid = true;
+  isValid = isBoolean(weatherConfig.enabled, `${pathPrefix}.enabled`) && isValid;
+  return isValid;
+}
+
 function validateChartStyles(chartStyles, themeName) {
   const basePath = `config.themes.${themeName}.CHART_STYLES`;
   const requiredProps = [
@@ -453,7 +460,7 @@ export function validateConfiguration(config) {
 
   let overallIsValid = true;
 
-  const rootProps = ['activeTheme', 'avatars', 'themes', 'profile', 'cache', 'apiDefaults', 'layout', 'wakatime'];
+  const rootProps = ['activeTheme', 'avatars', 'weather', 'themes', 'profile', 'cache', 'apiDefaults', 'layout', 'wakatime'];
   if (!validateObjectWithProps(config, 'config', rootProps)) {
     overallIsValid = false; 
   }
@@ -476,6 +483,7 @@ export function validateConfiguration(config) {
     }
     
     overallIsValid = validateAvatarsConfig(config.avatars) && overallIsValid;
+    overallIsValid = validateWeatherConfig(config.weather) && overallIsValid;
     overallIsValid = validateProfileConfig(config.profile) && overallIsValid;
     overallIsValid = validateCacheConfig(config.cache) && overallIsValid;
     overallIsValid = validateApiDefaultsConfig(config.apiDefaults) && overallIsValid;

--- a/tests/unit/services/data_sources/weatherDataSource.test.js
+++ b/tests/unit/services/data_sources/weatherDataSource.test.js
@@ -1,13 +1,16 @@
-// tests/unit/services/data_sources/weatherDataSource.test.js - COMPLETELY FIXED
+// tests/unit/services/data_sources/weatherDataSource.test.js
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('node-fetch', () => ({
   default: vi.fn()
 }));
 
-// Mock the config module
+// Mock the config module 
 vi.mock('../../../../src/config/config.js', () => ({
   config: {
+    weather: {
+      enabled: true 
+    },
     cache: {
       WEATHER_CACHE_TTL_MS: 1800000
     },
@@ -233,11 +236,7 @@ describe('weatherDataSource', () => {
       const result = await getWeatherData();
 
       expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        temperature: config.apiDefaults.TEMPERATURE,
-        weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
-        emoji: config.apiDefaults.WEATHER_EMOJI
-      });
+      expect(result).toEqual({});
     });
 
     it('should handle missing location key', async () => {
@@ -247,11 +246,7 @@ describe('weatherDataSource', () => {
       const result = await getWeatherData();
 
       expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        temperature: config.apiDefaults.TEMPERATURE,
-        weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
-        emoji: config.apiDefaults.WEATHER_EMOJI
-      });
+      expect(result).toEqual({});
     });
   });
 
@@ -259,7 +254,7 @@ describe('weatherDataSource', () => {
     const weatherEmojiTests = [
       { text: 'Sunny', emoji: '☀️' },
       { text: 'Clear skies', emoji: '☀️' },
-      { text: 'Mostly Sunny', emoji: '🌤️' },  // FIXED: Now correctly matches "mostly sunny" with improved logic
+      { text: 'Mostly Sunny', emoji: '🌤️' },
       { text: 'Partly Cloudy', emoji: '⛅' },
       { text: 'Cloudy', emoji: '☁️' },
       { text: 'Rain', emoji: '🌧️' },
@@ -283,6 +278,39 @@ describe('weatherDataSource', () => {
         const result = await getWeatherData();
         expect(result.emoji).toBe(emoji);
       });
+    });
+  });
+
+  describe('Weather Configuration', () => {
+    it('should skip weather fetch when config.weather.enabled is false', async () => {
+      // Mock config with weather disabled
+      vi.doMock('../../../../src/config/config.js', () => ({
+        config: {
+          weather: {
+            enabled: false
+          },
+          cache: {
+            WEATHER_CACHE_TTL_MS: 1800000
+          },
+          apiDefaults: {
+            TEMPERATURE: "72°F (22°C)",
+            WEATHER_DESCRIPTION: "partly cloudy",
+            WEATHER_EMOJI: "⛅"
+          }
+        }
+      }));
+
+      // Re-import to get updated config
+      vi.resetModules();
+      const module = await import('../../../../src/services/data_sources/weatherDataSource.js');
+      const getWeatherDataDisabled = module.getWeatherData;
+      
+      global.fetch = mockFetch;
+
+      const result = await getWeatherDataDisabled();
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toEqual({});
     });
   });
 });

--- a/tests/unit/utils/__tests__/ConfigValidator.test.js
+++ b/tests/unit/utils/__tests__/ConfigValidator.test.js
@@ -1,6 +1,7 @@
 /**
  * Unit tests for ConfigValidator.js
  * Tests configuration validation and helper functions
+ * FIXED: Added weather configuration to all test configs
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { validateConfiguration } from '../../../../src/utils/ConfigValidator.js';
@@ -30,6 +31,9 @@ describe('ConfigValidator', () => {
       shape: 'circle',
       xOffsetPx: 8,
       yOffsetPx: 0
+    },
+    weather: {
+      enabled: true
     },
     themes: {
       ios: {
@@ -332,9 +336,7 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('must be a string representing a number'));
     });
 
-    // NEW TESTS: Target specific uncovered lines
-
-    // NEW TEST: Profile config itself is null (targets validateObjectWithProps lines 264-265)
+    // Target specific uncovered lines
     it('should fail when profile config is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.profile = null;
@@ -343,7 +345,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.profile must be an object.');
     });
 
-    // NEW TEST: Profile config is not an object (targets validateObjectWithProps lines 264-265)
     it('should fail when profile config is not an object', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.profile = 'not-an-object';
@@ -352,7 +353,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.profile must be an object.');
     });
 
-    // NEW TEST: Layout ANIMATION object is null (targets validateObjectWithProps)
     it('should fail when layout ANIMATION object is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.layout.ANIMATION = null;
@@ -361,7 +361,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.layout.ANIMATION must be an object.');
     });
 
-    // NEW TEST: Layout ANIMATION object is not an object (targets validateObjectWithProps)
     it('should fail when layout ANIMATION object is not an object', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.layout.ANIMATION = 'not-an-object';
@@ -370,7 +369,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.layout.ANIMATION must be an object.');
     });
 
-    // NEW TEST: DOT_ANIMATION_DURATION is not a number (targets lines 296-298)
     it('should fail when DOT_ANIMATION_DURATION is not a number', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.layout.ANIMATION.DOT_ANIMATION_DURATION = 'not-a-number';
@@ -379,7 +377,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.layout.ANIMATION.DOT_ANIMATION_DURATION must be a number, got string.');
     });
 
-    // NEW TEST: STATUS_INDICATOR object is null
     it('should fail when STATUS_INDICATOR object is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.layout.STATUS_INDICATOR = null;
@@ -388,7 +385,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.layout.STATUS_INDICATOR must be an object.');
     });
 
-    // NEW TEST: TIMING object is null
     it('should fail when TIMING object is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.layout.TIMING = null;
@@ -397,7 +393,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.layout.TIMING must be an object.');
     });
 
-    // NEW TEST: Avatars me object is null
     it('should fail when avatars me object is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.avatars.me = null;
@@ -406,7 +401,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.avatars.me must be an object.');
     });
 
-    // NEW TEST: Avatars visitor object is null
     it('should fail when avatars visitor object is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.avatars.visitor = null;
@@ -415,7 +409,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.avatars.visitor must be an object.');
     });
 
-    // NEW TEST: Theme CHART_STYLES object is null
     it('should fail when theme CHART_STYLES object is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.themes.ios.CHART_STYLES = null;
@@ -424,7 +417,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.themes.ios.CHART_STYLES must be an object.');
     });
 
-    // NEW TEST: Wakatime defaults object is null
     it('should fail when wakatime defaults object is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.wakatime.defaults = null;
@@ -433,7 +425,6 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.wakatime.defaults must be an object.');
     });
 
-    // NEW TEST: Cache object is null
     it('should fail when cache object is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.cache = null;
@@ -442,13 +433,36 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.cache must be an object.');
     });
 
-    // NEW TEST: ApiDefaults object is null
     it('should fail when apiDefaults object is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.apiDefaults = null;
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.apiDefaults must be an object.');
+    });
+
+    // NEW TESTS: For weather configuration validation
+    it('should validate weather configuration correctly', () => {
+      const validConfig = createValidConfig();
+      validConfig.weather.enabled = false;
+      const result = validateConfiguration(validConfig);
+      expect(result).toBe(true);
+    });
+
+    it('should fail when weather config is missing', () => {
+      const invalidConfig = createValidConfig();
+      delete invalidConfig.weather;
+      const result = validateConfiguration(invalidConfig);
+      expect(result).toBe(false);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: Missing required property config.weather.');
+    });
+
+    it('should fail when weather.enabled is not a boolean', () => {
+      const invalidConfig = createValidConfig();
+      invalidConfig.weather.enabled = 'true';
+      const result = validateConfiguration(invalidConfig);
+      expect(result).toBe(false);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.weather.enabled must be a boolean, got string.');
     });
   });
 });


### PR DESCRIPTION
- Added config.weather.enabled flag (defaults to true)
- Updated weatherDataSource to check flag and API keys
- Added UI toggle for weather integration in ProfileEditor
- Updated ConfigValidator, configStore, README, and .env.template
- Resolves issue where weather API was implicitly required.