### PR TITLE
feat: Refactor Twitter to manual input, enhance API docs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,9 @@ WEATHER_API_KEY=YOUR_ACCUWEATHER_API_KEY_HERE
 # AccuWeather Location Key for your city
 # OPTIONAL: Weather integration can be disabled in configuration
 # Find your location key: https://developer.accuweather.com/accuweather-locations-api/apis
+# Example: Use the Location API search to find your city's key:
+# http://dataservice.accuweather.com/locations/v1/cities/search?apikey=YOUR_API_KEY&q=YOUR_CITY_NAME
+# Look for the "Key" value in the JSON response (e.g., "347628" for San Diego)
 LOCATION_KEY=YOUR_ACCUWEATHER_LOCATION_KEY_HERE
 
 # GitHub Personal Access Tokens
@@ -33,9 +36,21 @@ PAT_GITHUB_OAUTH=YOUR_GITHUB_OAUTH_PAT_HERE
 # Obtain from: https://wakatime.com/settings/api-key
 WAKATIME_API_KEY=YOUR_WAKATIME_API_KEY_HERE
 
-# Twitter API v2 Bearer Token
-# Obtain from your Twitter Developer Portal app settings
-TWITTER_BEARER_TOKEN=YOUR_TWITTER_BEARER_TOKEN_HERE
+# Twitter API v2 Bearer Token (ADVANCED - HIGH COST)
+# ⚠️  IMPORTANT: Twitter API now has SIGNIFICANT COSTS for follower endpoints
+# ⚠️  Live follower fetching is DISABLED BY DEFAULT due to these costs
+# ⚠️  ProfileChatter now uses manually entered follower counts by default
+#
+# To enable live API fetching (for advanced users aware of costs):
+# 1. Set twitter.enabled_api_fetch: true in your profileChatterConfig.json 
+#    (or src/config/config.js)
+# 2. Uncomment the line below and provide your Twitter Bearer Token
+# 3. Be aware that this will incur charges based on Twitter's current pricing
+#
+# Obtain from your Twitter Developer Portal app settings:
+# https://developer.twitter.com/en/portal/dashboard
+#
+# TWITTER_BEARER_TOKEN=YOUR_TWITTER_BEARER_TOKEN_HERE
 
 # OAuth Configurations
 

--- a/configurator-ui/src/components/ProfileEditor.svelte
+++ b/configurator-ui/src/components/ProfileEditor.svelte
@@ -320,6 +320,23 @@
         <p class="mt-1 text-xs text-gray-500">Leave empty to disable Twitter integration</p>
       </div>
       
+      <!-- TWITTER_FOLLOWERS (Manual) -->
+      <div class="mb-3">
+        <label for="twitter-followers" class="block text-sm font-medium text-gray-700 mb-1">
+          Twitter Followers (Manual)
+          <HelpIconTooltip text="Enter your follower count manually. Live API fetching is disabled by default due to Twitter API costs." />
+        </label>
+        <input 
+          type="text" 
+          id="twitter-followers" 
+          value={$userConfig.profile.TWITTER_FOLLOWERS || "0"}
+          on:input={(e) => updateProfileField('TWITTER_FOLLOWERS', e.target.value)}
+          class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary"
+          placeholder="1234"
+        />
+        <p class="mt-1 text-xs text-gray-500">Live API fetching is disabled by default due to Twitter API costs</p>
+      </div>
+      
       <!-- CODESTATS_USERNAME -->
       <div>
         <label for="codestats" class="block text-sm font-medium text-gray-700 mb-1">

--- a/configurator-ui/src/stores/configStore.js
+++ b/configurator-ui/src/stores/configStore.js
@@ -227,6 +227,7 @@ const initialProfileConfig = {
   GITHUB_USERNAME: "your_github",
   WAKATIME_USERNAME: "your_wakatime",
   TWITTER_USERNAME: "",
+  TWITTER_FOLLOWERS: "0",
   CODESTATS_USERNAME: "",
   TIMEZONE: "UTC" // Default timezone
 };
@@ -564,6 +565,7 @@ export const userConfig = writable({
   activeTheme: "ios",
   avatars: structuredClone(initialAvatarsConfig),
   weather: structuredClone(initialWeatherConfig),
+  twitter: { enabled_api_fetch: false },
   layout: { 
     ANIMATION: { 
       SCROLL_SPEED_MULTIPLIER: 1.0 
@@ -684,6 +686,7 @@ export function getPreviewConfiguration() {
     activeTheme: currentConfig.activeTheme,
     avatars: currentConfig.avatars,
     weather: currentConfig.weather,
+    twitter: currentConfig.twitter,
     chatMessages: currentMessages,
     themeOverrides: currentTheme,
     layoutAnimationOverrides: {

--- a/profileChatterConfig.json
+++ b/profileChatterConfig.json
@@ -7,7 +7,8 @@
     "CURRENT_PROJECT": "ProfileChatter, an SVG Generator",
     "GITHUB_USERNAME": "dsj7419",
     "WAKATIME_USERNAME": "dsj7419",
-    "TWITTER_USERNAME": "dsj7419",
+    "TWITTER_USERNAME": "",
+    "TWITTER_FOLLOWERS": "120",
     "CODESTATS_USERNAME": "dsj7419",
     "TIMEZONE": "America/Los_Angeles",
     "WORK_START_DATE": {
@@ -31,6 +32,12 @@
     "shape": "circle",
     "xOffsetPx": 8,
     "yOffsetPx": 0
+  },
+  "weather": {
+    "enabled": true
+  },
+  "twitter": {
+    "enabled_api_fetch": false
   },
   "chatMessages": [
     {
@@ -180,7 +187,7 @@
     "ME_TEXT_COLOR": "#FFFFFF",
     "VISITOR_TEXT_COLOR": "#000000",
     "BACKGROUND_LIGHT": "#FFFFFF",
-    "BACKGROUND_DARK": "#000028",
+    "BACKGROUND_DARK": "#00001a",
     "BUBBLE_RADIUS_PX": 18,
     "FONT_FAMILY": "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
     "REACTION_FONT_SIZE_PX": 20,

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -23,6 +23,10 @@ export const config = {
     enabled: true
   },
 
+  twitter: {
+    enabled_api_fetch: false
+  },
+
   themes: {
     ios: {
       ME_BUBBLE_COLOR: '#0B93F6',
@@ -221,6 +225,7 @@ export const config = {
     GITHUB_USERNAME: "dsj7419",
     WAKATIME_USERNAME: "dsj7419",
     TWITTER_USERNAME: "",
+    TWITTER_FOLLOWERS: "0",
     CODESTATS_USERNAME: "dsj7419",
     TIMEZONE: 'UTC', // Default timezone
   },

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -92,7 +92,21 @@ class DataService {
           getSpotifyData(),
           getGitHubOAuthData()
         ]);
-        Object.assign(baseData, weather, github, wakatime, twitter, codestats, spotify, githubOAuth);
+        Object.assign(baseData, weather, github, wakatime, codestats, spotify, githubOAuth);
+
+        // Handle Twitter followers with manual input priority
+        if (customData.profile?.TWITTER_FOLLOWERS) {
+          // Prioritize customData.profile.TWITTER_FOLLOWERS (from UI/profileChatterConfig.json)
+          baseData.twitterFollowers = customData.profile.TWITTER_FOLLOWERS;
+        } else if (config.profile.TWITTER_FOLLOWERS) {
+          // Then config.profile.TWITTER_FOLLOWERS (from src/config/config.js)
+          baseData.twitterFollowers = config.profile.TWITTER_FOLLOWERS;
+        } else if (config.twitter.enabled_api_fetch && twitter.twitterFollowers) {
+          // Then, if API fetching is enabled and successful, use that value
+          baseData.twitterFollowers = twitter.twitterFollowers;
+        }
+        // Finally, fall back to config.apiDefaults.TWITTER_FOLLOWERS (already set above)
+
       } catch (apiErr) {
         console.error('Error fetching APIs:', apiErr.message);
         console.info('Using defaults already in baseData.');

--- a/src/services/data_sources/twitterDataSource.js
+++ b/src/services/data_sources/twitterDataSource.js
@@ -14,6 +14,12 @@ let twitterCache = { data: null, expiresAt: 0 }
  */
 export async function getTwitterData () {
   try {
+    // First check if API fetching is enabled
+    if (!config.twitter.enabled_api_fetch) {
+      console.info('Twitter API fetch is disabled. Manual follower count will be used.')
+      return {}
+    }
+
     const username = config.profile.TWITTER_USERNAME
     if (!username) {
       console.info('Twitter username not configured – skipping Twitter call.')
@@ -27,7 +33,10 @@ export async function getTwitterData () {
     }
 
     const token = process.env.TWITTER_BEARER_TOKEN
-    if (!token) throw new Error('TWITTER_BEARER_TOKEN not set in environment.')
+    if (!token) {
+      console.info('Twitter API fetch enabled but TWITTER_BEARER_TOKEN is missing. Manual follower count will be used.')
+      return {}
+    }
 
     const endpoint = `https://api.twitter.com/2/users/by/username/${encodeURIComponent(username)}?user.fields=public_metrics`
     const fetchImpl = typeof fetch === 'function' ? fetch : (await import('node-fetch')).default

--- a/src/utils/ConfigValidator.js
+++ b/src/utils/ConfigValidator.js
@@ -81,8 +81,12 @@ function isValidDate(value, propertyPath) {
   return true;
 }
 function isStringRepresentingNumber(value, propertyPath) {
-  if (!isNonEmptyString(value, propertyPath)) {
+  if (!isString(value, propertyPath)) {
     return false;
+  }
+  if (value === '') {
+    // Allow empty strings for optional numeric fields
+    return true;
   }
   if (isNaN(Number(value))) {
     console.error(`Configuration error: ${propertyPath} must be a string representing a number, got '${value}'.`);
@@ -148,6 +152,13 @@ function validateWeatherConfig(weatherConfig, pathPrefix = 'config.weather') {
   if (!validateObjectWithProps(weatherConfig, pathPrefix, ['enabled'])) return false;
   let isValid = true;
   isValid = isBoolean(weatherConfig.enabled, `${pathPrefix}.enabled`) && isValid;
+  return isValid;
+}
+
+function validateTwitterConfig(twitterConfig, pathPrefix = 'config.twitter') {
+  if (!validateObjectWithProps(twitterConfig, pathPrefix, ['enabled_api_fetch'])) return false;
+  let isValid = true;
+  isValid = isBoolean(twitterConfig.enabled_api_fetch, `${pathPrefix}.enabled_api_fetch`) && isValid;
   return isValid;
 }
 
@@ -255,7 +266,7 @@ function validateTheme(theme, themeName) {
 }
 
 function validateProfileConfig(profileConfig, pathPrefix = 'config.profile') {
-  const requiredProps = ['NAME', 'PROFESSION', 'LOCATION', 'COMPANY', 'CURRENT_PROJECT', 'GITHUB_USERNAME', 'WAKATIME_USERNAME', 'TWITTER_USERNAME', 'CODESTATS_USERNAME'];
+  const requiredProps = ['NAME', 'PROFESSION', 'LOCATION', 'COMPANY', 'CURRENT_PROJECT', 'GITHUB_USERNAME', 'WAKATIME_USERNAME', 'TWITTER_USERNAME', 'TWITTER_FOLLOWERS', 'CODESTATS_USERNAME'];
   
   if (!validateObjectWithProps(profileConfig, pathPrefix, requiredProps)) return false;
   
@@ -313,6 +324,7 @@ function validateProfileConfig(profileConfig, pathPrefix = 'config.profile') {
   if (profileConfig.TWITTER_USERNAME !== '') {
     isValid = isNonEmptyString(profileConfig.TWITTER_USERNAME, `${pathPrefix}.TWITTER_USERNAME`) && isValid;
   }
+  isValid = isStringRepresentingNumber(profileConfig.TWITTER_FOLLOWERS, `${pathPrefix}.TWITTER_FOLLOWERS`) && isValid;
   if (profileConfig.CODESTATS_USERNAME !== '') {
     isValid = isNonEmptyString(profileConfig.CODESTATS_USERNAME, `${pathPrefix}.CODESTATS_USERNAME`) && isValid;
   }
@@ -460,7 +472,7 @@ export function validateConfiguration(config) {
 
   let overallIsValid = true;
 
-  const rootProps = ['activeTheme', 'avatars', 'weather', 'themes', 'profile', 'cache', 'apiDefaults', 'layout', 'wakatime'];
+  const rootProps = ['activeTheme', 'avatars', 'weather', 'twitter', 'themes', 'profile', 'cache', 'apiDefaults', 'layout', 'wakatime'];
   if (!validateObjectWithProps(config, 'config', rootProps)) {
     overallIsValid = false; 
   }
@@ -484,6 +496,7 @@ export function validateConfiguration(config) {
     
     overallIsValid = validateAvatarsConfig(config.avatars) && overallIsValid;
     overallIsValid = validateWeatherConfig(config.weather) && overallIsValid;
+    overallIsValid = validateTwitterConfig(config.twitter) && overallIsValid;
     overallIsValid = validateProfileConfig(config.profile) && overallIsValid;
     overallIsValid = validateCacheConfig(config.cache) && overallIsValid;
     overallIsValid = validateApiDefaultsConfig(config.apiDefaults) && overallIsValid;

--- a/tests/unit/services/__tests__/DataService.test.js
+++ b/tests/unit/services/__tests__/DataService.test.js
@@ -179,7 +179,7 @@ describe('DataService', () => {
       expect(result.temperature).toBe('75°F (24°C)');
       expect(result.githubPublicRepos).toBe('15');
       expect(result.wakatime_summary).toBe('Coded for 8 hrs');
-      expect(result.twitterFollowers).toBe('150');
+      expect(result.twitterFollowers).toBe('100');
       expect(result.codestatsXP).toBe('2500');
       expect(result.spotifyTrack).toBe('Test Song by Test Artist');
       expect(result.githubTotalStars).toBe('50');

--- a/tests/unit/services/data_sources/twitterDataSource.test.js
+++ b/tests/unit/services/data_sources/twitterDataSource.test.js
@@ -1,273 +1,288 @@
-// tests/unit/services/data_sources/twitterDataSource.test.js - COMPLETELY FIXED
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+/**
+ * twitterDataSource.test.js
+ * Unit tests for Twitter data source with manual input support
+ */
 
-vi.mock('node-fetch', () => ({
-  default: vi.fn()
-}));
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-// Mock the config module
+// Mock the config module with inline object to avoid hoisting issues
 vi.mock('../../../../src/config/config.js', () => ({
   config: {
+    twitter: {
+      enabled_api_fetch: false
+    },
     profile: {
-      TWITTER_USERNAME: 'testuser' // Default test value
+      TWITTER_USERNAME: 'testuser'
     },
     cache: {
       TWITTER_CACHE_TTL_MS: 3600000
     },
     apiDefaults: {
-      TWITTER_FOLLOWERS: '120'
+      TWITTER_FOLLOWERS: '100'
     }
   }
 }));
 
 describe('twitterDataSource', () => {
   let mockFetch;
+  let originalEnv;
+  let consoleSpy;
+  let mockConfig;
   let getTwitterData;
-  let config;
-  const originalEnv = process.env;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.useFakeTimers();
-    
-    // Reset module
+    // Clear module cache to ensure fresh imports
     vi.resetModules();
     
-    process.env = { ...originalEnv };
-    process.env.TWITTER_BEARER_TOKEN = 'test-bearer-token';
-    
-    // Import fresh modules
+    // Get the mocked config
     const configModule = await import('../../../../src/config/config.js');
-    config = configModule.config;
+    mockConfig = configModule.config;
     
-    // Set default test username
-    config.profile.TWITTER_USERNAME = 'testuser';
+    // Import the function fresh for each test
+    const twitterModule = await import('../../../../src/services/data_sources/twitterDataSource.js');
+    getTwitterData = twitterModule.getTwitterData;
     
-    const module = await import('../../../../src/services/data_sources/twitterDataSource.js');
-    getTwitterData = module.getTwitterData;
+    // Store original environment
+    originalEnv = process.env.TWITTER_BEARER_TOKEN;
     
+    // Setup console spy
+    consoleSpy = {
+      info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+      error: vi.spyOn(console, 'error').mockImplementation(() => {})
+    };
+
+    // Setup fetch mock
     mockFetch = vi.fn();
-    if (typeof fetch === 'undefined') {
-      global.fetch = undefined;
-    }
+    global.fetch = mockFetch;
+
+    // Reset mock config to default state
+    mockConfig.twitter.enabled_api_fetch = false;
+    mockConfig.profile.TWITTER_USERNAME = 'testuser';
   });
 
   afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    process.env = originalEnv;
-    if (global.fetch === undefined) {
-      delete global.fetch;
+    // Restore environment
+    if (originalEnv !== undefined) {
+      process.env.TWITTER_BEARER_TOKEN = originalEnv;
+    } else {
+      delete process.env.TWITTER_BEARER_TOKEN;
     }
+    
+    // Restore all mocks
+    vi.restoreAllMocks();
   });
 
-  describe('Configuration Checks', () => {
-    it('should skip when username not configured', async () => {
-      config.profile.TWITTER_USERNAME = '';
-      global.fetch = mockFetch;
-
-      const result = await getTwitterData();
-
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({}); // Should return empty object, not default
+  describe('when API fetch is disabled', () => {
+    beforeEach(() => {
+      // Set config to disabled state
+      mockConfig.twitter.enabled_api_fetch = false;
     });
 
-    it('should handle missing bearer token', async () => {
-      delete process.env.TWITTER_BEARER_TOKEN;
-      global.fetch = mockFetch;
-
+    it('should return empty object and log info message', async () => {
       const result = await getTwitterData();
-
+      
+      expect(result).toEqual({});
+      expect(consoleSpy.info).toHaveBeenCalledWith('Twitter API fetch is disabled. Manual follower count will be used.');
       expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        twitterFollowers: config.apiDefaults.TWITTER_FOLLOWERS
+    });
+  });
+
+  describe('when API fetch is enabled', () => {
+    beforeEach(() => {
+      // Set config to enabled state
+      mockConfig.twitter.enabled_api_fetch = true;
+      mockConfig.profile.TWITTER_USERNAME = 'testuser';
+    });
+
+    describe('but no username is configured', () => {
+      beforeEach(() => {
+        mockConfig.profile.TWITTER_USERNAME = '';
+      });
+
+      it('should return empty object and log info message', async () => {
+        const result = await getTwitterData();
+        
+        expect(result).toEqual({});
+        expect(consoleSpy.info).toHaveBeenCalledWith('Twitter username not configured – skipping Twitter call.');
+        expect(mockFetch).not.toHaveBeenCalled();
       });
     });
-  });
 
-  describe('Successful API Fetch & Caching', () => {
-    it('should fetch Twitter data successfully', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+    describe('but no bearer token is provided', () => {
+      beforeEach(() => {
+        delete process.env.TWITTER_BEARER_TOKEN;
+      });
+
+      it('should return empty object and log info message', async () => {
+        const result = await getTwitterData();
+        
+        expect(result).toEqual({});
+        expect(consoleSpy.info).toHaveBeenCalledWith('Twitter API fetch enabled but TWITTER_BEARER_TOKEN is missing. Manual follower count will be used.');
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('with valid configuration', () => {
+      beforeEach(() => {
+        process.env.TWITTER_BEARER_TOKEN = 'test_token';
+      });
+
+      it('should successfully fetch and return follower count', async () => {
+        const mockResponse = {
           data: {
             public_metrics: {
-              followers_count: 5000
+              followers_count: 1250
             }
           }
-        })
-      });
+        };
 
-      const result = await getTwitterData();
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.twitter.com/2/users/by/username/testuser?user.fields=public_metrics',
-        {
-          headers: { Authorization: 'Bearer test-bearer-token' }
-        }
-      );
-      expect(result).toEqual({ twitterFollowers: '5000' });
-    });
-
-    it('should handle missing bearer token', async () => {
-      delete process.env.TWITTER_BEARER_TOKEN;
-      global.fetch = mockFetch;
-
-      const result = await getTwitterData();
-
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        twitterFollowers: config.apiDefaults.TWITTER_FOLLOWERS
-      });
-    });
-
-    it('should fetch Twitter data successfully', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: {
-            public_metrics: {
-              followers_count: 5000
-            }
-          }
-        })
-      });
-
-      const result = await getTwitterData();
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.twitter.com/2/users/by/username/testuser?user.fields=public_metrics',
-        {
-          headers: { Authorization: 'Bearer test-bearer-token' }
-        }
-      );
-      expect(result).toEqual({ twitterFollowers: '5000' });
-    });
-
-    it('should handle invalid response data', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ data: {} })
-      });
-
-      const result = await getTwitterData();
-
-      expect(result).toEqual({
-        twitterFollowers: config.apiDefaults.TWITTER_FOLLOWERS
-      });
-    });
-
-    it('should use cached data', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: { public_metrics: { followers_count: 1234 } }
-        })
-      });
-
-      await getTwitterData();
-      const result = await getTwitterData();
-
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({ twitterFollowers: '1234' });
-    });
-
-    it('should refresh after cache expires', async () => {
-      global.fetch = mockFetch;
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            data: { public_metrics: { followers_count: 100 } }
-          })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            data: { public_metrics: { followers_count: 200 } }
-          })
-        });
-
-      await getTwitterData();
-      vi.advanceTimersByTime(config.cache.TWITTER_CACHE_TTL_MS + 1000);
-      const result = await getTwitterData();
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(result).toEqual({ twitterFollowers: '200' });
-    });
-  });
-
-  describe('API Error Handling', () => {
-    const errorTests = [
-      { status: 401, message: 'Unauthorized – invalid bearer token.' },
-      { status: 403, message: 'Forbidden – check app permissions.' },
-      { status: 404, message: 'User "testuser" not found.' },
-      { status: 429, message: 'Rate‑limit exceeded.' }
-    ];
-
-    errorTests.forEach(({ status }) => {
-      it(`should handle ${status} error`, async () => {
-        global.fetch = mockFetch;
         mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status,
-          statusText: 'Error'
+          ok: true,
+          json: () => Promise.resolve(mockResponse)
         });
 
         const result = await getTwitterData();
 
-        expect(result).toEqual({
-          twitterFollowers: config.apiDefaults.TWITTER_FOLLOWERS
+        expect(result).toEqual({ twitterFollowers: '1250' });
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://api.twitter.com/2/users/by/username/testuser?user.fields=public_metrics',
+          {
+            headers: { Authorization: 'Bearer test_token' }
+          }
+        );
+        expect(consoleSpy.info).toHaveBeenCalledWith('Twitter data fetched & cached.');
+      });
+
+      it('should handle 401 unauthorized error', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized'
         });
-      });
-    });
 
-    it('should handle generic errors', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: 'Server Error'
+        const result = await getTwitterData();
+
+        expect(result).toEqual({ twitterFollowers: '100' });
+        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Unauthorized – invalid bearer token.');
+        expect(consoleSpy.info).toHaveBeenCalledWith('Using default follower count.');
       });
 
-      const result = await getTwitterData();
+      it('should handle 403 forbidden error', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden'
+        });
 
-      expect(result).toEqual({
-        twitterFollowers: config.apiDefaults.TWITTER_FOLLOWERS
-      });
-    });
+        const result = await getTwitterData();
 
-    it('should handle network errors', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-      const result = await getTwitterData();
-
-      expect(result).toEqual({
-        twitterFollowers: config.apiDefaults.TWITTER_FOLLOWERS
-      });
-    });
-  });
-
-  describe('Node Environment', () => {
-    it('should use node-fetch in Node', async () => {
-      delete global.fetch;
-      const nodeFetch = (await import('node-fetch')).default;
-      nodeFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: { public_metrics: { followers_count: 999 } }
-        })
+        expect(result).toEqual({ twitterFollowers: '100' });
+        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Forbidden – check app permissions.');
       });
 
-      const result = await getTwitterData();
+      it('should handle 404 user not found error', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found'
+        });
 
-      expect(nodeFetch).toHaveBeenCalled();
-      expect(result).toEqual({ twitterFollowers: '999' });
+        const result = await getTwitterData();
+
+        expect(result).toEqual({ twitterFollowers: '100' });
+        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'User "testuser" not found.');
+      });
+
+      it('should handle 429 rate limit error', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests'
+        });
+
+        const result = await getTwitterData();
+
+        expect(result).toEqual({ twitterFollowers: '100' });
+        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Rate‑limit exceeded.');
+      });
+
+      it('should handle other HTTP errors', async () => {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error'
+        });
+
+        const result = await getTwitterData();
+
+        expect(result).toEqual({ twitterFollowers: '100' });
+        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Twitter API 500: Internal Server Error');
+      });
+
+      it('should handle invalid response data', async () => {
+        const mockResponse = {
+          data: {
+            public_metrics: {
+              followers_count: 'invalid'
+            }
+          }
+        };
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockResponse)
+        });
+
+        const result = await getTwitterData();
+
+        expect(result).toEqual({ twitterFollowers: '100' });
+        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Twitter API returned invalid follower count.');
+      });
+
+      it('should handle network errors', async () => {
+        mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+        const result = await getTwitterData();
+
+        expect(result).toEqual({ twitterFollowers: '100' });
+        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Network error');
+      });
+
+      it('should return cached data when cache is fresh', async () => {
+        const mockResponse = {
+          data: {
+            public_metrics: {
+              followers_count: 1250
+            }
+          }
+        };
+
+        // Mock Date.now for consistent caching behavior
+        const mockDate = vi.spyOn(Date, 'now');
+        const baseTime = 1000000;
+        mockDate.mockReturnValue(baseTime);
+
+        // First call - should fetch from API
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockResponse)
+        });
+
+        const firstResult = await getTwitterData();
+        expect(firstResult).toEqual({ twitterFollowers: '1250' });
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+
+        // Second call - should use cache (advance time but stay within cache TTL)
+        const cacheTime = baseTime + 1800000; // 30 minutes later (within 1 hour TTL)
+        mockDate.mockReturnValue(cacheTime);
+
+        const secondResult = await getTwitterData();
+        expect(secondResult).toEqual({ twitterFollowers: '1250' });
+        expect(mockFetch).toHaveBeenCalledTimes(1); // Still only 1 call - used cache
+        expect(consoleSpy.info).toHaveBeenCalledWith('Using cached Twitter data.');
+
+        mockDate.mockRestore();
+      });
     });
   });
 });

--- a/tests/unit/utils/__tests__/ConfigValidator.test.js
+++ b/tests/unit/utils/__tests__/ConfigValidator.test.js
@@ -1,202 +1,205 @@
 /**
- * Unit tests for ConfigValidator.js
- * Tests configuration validation and helper functions
- * FIXED: Added weather configuration to all test configs
+ * ConfigValidator.test.js
+ * Unit tests for configuration validation including Twitter manual input support
  */
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { validateConfiguration } from '../../../../src/utils/ConfigValidator.js';
 
 describe('ConfigValidator', () => {
   let consoleErrorSpy;
-  let consoleWarnSpy;
 
   beforeEach(() => {
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    consoleErrorSpy.mockRestore();
-    consoleWarnSpy.mockRestore();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
-  const createValidConfig = () => ({
-    activeTheme: 'ios',
-    avatars: {
-      enabled: true,
-      me: { imageUrl: '', fallbackText: 'DJ' },
-      visitor: { imageUrl: '', fallbackText: '?' },
-      sizePx: 32,
-      shape: 'circle',
-      xOffsetPx: 8,
-      yOffsetPx: 0
-    },
-    weather: {
-      enabled: true
-    },
-    themes: {
-      ios: {
-        ME_BUBBLE_COLOR: '#0B93F6',
-        VISITOR_BUBBLE_COLOR: '#E5E5EA',
-        ME_TEXT_COLOR: '#FFFFFF',
-        VISITOR_TEXT_COLOR: '#000000',
-        BACKGROUND_LIGHT: '#FFFFFF',
-        BACKGROUND_DARK: '#000000',
-        BUBBLE_RADIUS_PX: 18,
-        FONT_FAMILY: 'Arial',
-        REACTION_FONT_SIZE_PX: 20,
-        REACTION_BG_COLOR: '#F1F1F1',
-        REACTION_BG_OPACITY: 0.9,
-        REACTION_TEXT_COLOR: '#000000',
-        REACTION_PADDING_X_PX: 8,
-        REACTION_PADDING_Y_PX: 4,
-        REACTION_BORDER_RADIUS_PX: 14,
-        REACTION_OFFSET_X_PX: 0,
-        REACTION_OFFSET_Y_PX: -12,
-        CHART_STYLES: {
-          BAR_DEFAULT_COLOR: '#007AFF',
-          BAR_TRACK_COLOR: '#D3D3D8',
-          BAR_CORNER_RADIUS_PX: 8,
-          VALUE_TEXT_INSIDE_COLOR: '#FFFFFF',
-          BAR_HEIGHT_PX: 18,
-          BAR_SPACING_PX: 10,
-          LABEL_FONT_FAMILY: 'Arial',
-          LABEL_FONT_SIZE_PX: 13,
-          VALUE_TEXT_FONT_FAMILY: 'Arial',
-          VALUE_TEXT_FONT_SIZE_PX: 12,
-          TITLE_FONT_FAMILY: 'Arial',
-          TITLE_FONT_SIZE_PX: 15,
-          TITLE_LINE_HEIGHT_MULTIPLIER: 1.3,
-          TITLE_BOTTOM_MARGIN_PX: 10,
-          CHART_PADDING_X_PX: 16,
-          CHART_PADDING_Y_PX: 14,
-          AXIS_LINE_COLOR: '#D3D3D8',
-          GRID_LINE_COLOR: '#F5F5F5',
-          ME_TITLE_COLOR: '#FFFFFF',
-          ME_LABEL_COLOR: '#E2F0FF',
-          ME_VALUE_TEXT_COLOR: '#FFFFFF',
-          VISITOR_TITLE_COLOR: '#000000',
-          VISITOR_LABEL_COLOR: '#444444',
-          VISITOR_VALUE_TEXT_COLOR: '#000000',
-          DONUT_STROKE_WIDTH_PX: 30,
-          DONUT_CENTER_TEXT_FONT_SIZE_PX: 16,
-          DONUT_CENTER_TEXT_FONT_FAMILY: 'Arial',
-          ME_DONUT_CENTER_TEXT_COLOR: '#FFFFFF',
-          VISITOR_DONUT_CENTER_TEXT_COLOR: '#000000',
-          ME_DONUT_LEGEND_TEXT_COLOR: '#FFFFFF',
-          VISITOR_DONUT_LEGEND_TEXT_COLOR: '#000000',
-          DONUT_LEGEND_FONT_SIZE_PX: 12,
-          DONUT_LEGEND_ITEM_SPACING_PX: 8,
-          DONUT_LEGEND_MARKER_SIZE_PX: 10,
-          DONUT_ANIMATION_DURATION_SEC: 1.0,
-          DONUT_SEGMENT_ANIMATION_DELAY_SEC: 0.2
+  // Helper function to create a valid configuration
+  function createValidConfig() {
+    return {
+      activeTheme: 'ios',
+      avatars: {
+        enabled: true,
+        me: { imageUrl: 'test.jpg', fallbackText: 'ME' },
+        visitor: { imageUrl: 'visitor.jpg', fallbackText: 'V' },
+        sizePx: 32,
+        shape: 'circle',
+        xOffsetPx: 0,
+        yOffsetPx: 0
+      },
+      weather: {
+        enabled: true
+      },
+      twitter: {
+        enabled_api_fetch: false
+      },
+      themes: {
+        ios: {
+          ME_BUBBLE_COLOR: '#0B93F6',
+          VISITOR_BUBBLE_COLOR: '#E5E5EA',
+          ME_TEXT_COLOR: '#FFFFFF',
+          VISITOR_TEXT_COLOR: '#000000',
+          BACKGROUND_LIGHT: '#FFFFFF',
+          BACKGROUND_DARK: '#000000',
+          BUBBLE_RADIUS_PX: 18,
+          FONT_FAMILY: 'Arial, sans-serif',
+          REACTION_FONT_SIZE_PX: 20,
+          REACTION_BG_COLOR: '#F1F1F1',
+          REACTION_BG_OPACITY: 0.9,
+          REACTION_TEXT_COLOR: '#000000',
+          REACTION_PADDING_X_PX: 8,
+          REACTION_PADDING_Y_PX: 4,
+          REACTION_BORDER_RADIUS_PX: 14,
+          REACTION_OFFSET_X_PX: 0,
+          REACTION_OFFSET_Y_PX: -12,
+          CHART_STYLES: {
+            BAR_DEFAULT_COLOR: '#007AFF',
+            BAR_TRACK_COLOR: '#D3D3D8',
+            BAR_CORNER_RADIUS_PX: 8,
+            VALUE_TEXT_INSIDE_COLOR: '#FFFFFF',
+            BAR_HEIGHT_PX: 18,
+            BAR_SPACING_PX: 10,
+            LABEL_FONT_FAMILY: 'Arial, sans-serif',
+            LABEL_FONT_SIZE_PX: 13,
+            VALUE_TEXT_FONT_FAMILY: 'Arial, sans-serif',
+            VALUE_TEXT_FONT_SIZE_PX: 12,
+            TITLE_FONT_FAMILY: 'Arial, sans-serif',
+            TITLE_FONT_SIZE_PX: 15,
+            TITLE_LINE_HEIGHT_MULTIPLIER: 1.3,
+            TITLE_BOTTOM_MARGIN_PX: 10,
+            CHART_PADDING_X_PX: 16,
+            CHART_PADDING_Y_PX: 14,
+            AXIS_LINE_COLOR: '#D3D3D8',
+            GRID_LINE_COLOR: '#F5F5F5',
+            ME_TITLE_COLOR: '#FFFFFF',
+            ME_LABEL_COLOR: '#E2F0FF',
+            ME_VALUE_TEXT_COLOR: '#FFFFFF',
+            VISITOR_TITLE_COLOR: '#000000',
+            VISITOR_LABEL_COLOR: '#444444',
+            VISITOR_VALUE_TEXT_COLOR: '#000000',
+            DONUT_STROKE_WIDTH_PX: 30,
+            DONUT_CENTER_TEXT_FONT_SIZE_PX: 16,
+            DONUT_CENTER_TEXT_FONT_FAMILY: 'Arial, sans-serif',
+            ME_DONUT_CENTER_TEXT_COLOR: '#FFFFFF',
+            VISITOR_DONUT_CENTER_TEXT_COLOR: '#000000',
+            ME_DONUT_LEGEND_TEXT_COLOR: '#FFFFFF',
+            VISITOR_DONUT_LEGEND_TEXT_COLOR: '#000000',
+            DONUT_LEGEND_FONT_SIZE_PX: 12,
+            DONUT_LEGEND_ITEM_SPACING_PX: 8,
+            DONUT_LEGEND_MARKER_SIZE_PX: 10,
+            DONUT_ANIMATION_DURATION_SEC: 1.0,
+            DONUT_SEGMENT_ANIMATION_DELAY_SEC: 0.2
+          }
         }
+      },
+      profile: {
+        NAME: 'Test User',
+        PROFESSION: 'Developer',
+        LOCATION: 'Test City',
+        COMPANY: 'Test Company',
+        CURRENT_PROJECT: 'Test Project',
+        WORK_START_DATE: new Date(2020, 0, 1),
+        GITHUB_USERNAME: 'testuser',
+        WAKATIME_USERNAME: 'testuser',
+        TWITTER_USERNAME: 'testuser',
+        TWITTER_FOLLOWERS: '100',
+        CODESTATS_USERNAME: 'testuser'
+      },
+      cache: {
+        WEATHER_CACHE_TTL_MS: 1800000,
+        GITHUB_CACHE_TTL_MS: 3600000,
+        TWITTER_CACHE_TTL_MS: 3600000,
+        CODESTATS_CACHE_TTL_MS: 7200000
+      },
+      apiDefaults: {
+        TEMPERATURE: '72°F',
+        WEATHER_DESCRIPTION: 'sunny',
+        WEATHER_EMOJI: '☀️',
+        GITHUB_PUBLIC_REPOS: '10',
+        GITHUB_FOLLOWERS: '50',
+        TWITTER_FOLLOWERS: '100',
+        CODESTATS_XP: '1000'
+      },
+      layout: {
+        FONT_SIZE_PX: 14,
+        LINE_HEIGHT_PX: 20,
+        CHAT_WIDTH_PX: 320,
+        CHAT_HEIGHT_PX: 450,
+        BUBBLE_PAD_X_PX: 12,
+        BUBBLE_PAD_Y_PX: 8,
+        MIN_BUBBLE_W_PX: 40,
+        MAX_BUBBLE_W_PX: 260,
+        BUBBLE_TAIL_HEIGHT_PX: 25,
+        BUBBLE_TAIL_WIDTH_PX: 20,
+        BUBBLE_TAIL_EXT_WIDTH_PX: 26,
+        BUBBLE_TAIL_RADIUS_X: 16,
+        BUBBLE_TAIL_RADIUS_Y: 14,
+        TYPING_DOT_RADIUS_PX: 4,
+        TYPING_CHAR_MS: 40,
+        TYPING_MIN_MS: 1600,
+        TYPING_MAX_MS: 3000,
+        VISIBLE_MESSAGES: 6,
+        STATUS_INDICATOR: {
+          DELIVERED_TEXT: 'Delivered',
+          READ_TEXT: 'Read',
+          FONT_SIZE_PX: 10,
+          COLOR_ME: '#FFFFFF',
+          OFFSET_Y_PX: 10,
+          ANIMATION_DELAY_SEC: 0.2,
+          FADE_IN_DURATION_SEC: 0.3,
+          READ_DELAY_SEC: 1.5,
+          READ_TRANSITION_SEC: 0.2
+        },
+        TIMING: {
+          MIN_READING_TIME_MS: 1000,
+          MS_PER_WORD: 250,
+          READING_RANDOMNESS_MS: 1000,
+          SAME_SENDER_DELAY_MS: 600,
+          SENDER_CHANGE_DELAY_MS: 1800,
+          MESSAGE_VERTICAL_SPACING: 32,
+          BOTTOM_MARGIN: 40,
+          ANIMATION_END_BUFFER_MS: 2000
+        },
+        ANIMATION: {
+          TYPING_BUBBLE_WIDTH: 70,
+          TYPING_BUBBLE_HEIGHT: 36,
+          DOT_ANIMATION_DURATION: 1.4,
+          DOT_DELAY_2: 0.2,
+          DOT_DELAY_3: 0.4,
+          DOT_MIN_OPACITY: 0.4,
+          DOT_MAX_OPACITY: 1.0,
+          DOT_MIN_SCALE: 0.8,
+          DOT_MAX_SCALE: 1.0,
+          BUBBLE_ANIMATION_DURATION: 0.36,
+          BUBBLE_ANIMATION_CURVE: 'cubic-bezier(.36,1.64,.36,1)',
+          BUBBLE_START_SCALE: 0.8,
+          REACTION_ANIMATION_DURATION_SEC: 0.3,
+          REACTION_ANIMATION_DELAY_FACTOR_SEC: 1.1,
+          CHART_BAR_ANIMATION_DURATION_SEC: 0.8,
+          CHART_ANIMATION_DELAY_SEC: 0.3,
+          SHADOW_BLUR: 1,
+          SHADOW_OFFSET_X: 0,
+          SHADOW_OFFSET_Y: 1,
+          SHADOW_OPACITY: 0.15,
+          SCROLL_DELAY_BUFFER_SEC: 2.2,
+          MIN_SCROLL_DURATION_SEC: 1.2,
+          SCROLL_PIXELS_PER_SEC: 18
+        }
+      },
+      wakatime: {
+        enabled: true,
+        defaults: {
+          wakatime_summary: 'No data',
+          wakatime_top_language: 'JavaScript',
+          wakatime_top_language_percent: '0'
+        },
+        cacheTtlMs: 7200000
       }
-    },
-    profile: {
-      NAME: 'John Doe',
-      PROFESSION: 'Developer',
-      LOCATION: 'City',
-      COMPANY: 'Company',
-      CURRENT_PROJECT: 'Project',
-      WORK_START_DATE: new Date(2020, 0, 1),
-      GITHUB_USERNAME: 'johndoe',
-      WAKATIME_USERNAME: 'johndoe',
-      TWITTER_USERNAME: 'johndoe',
-      CODESTATS_USERNAME: 'johndoe'
-    },
-    cache: {
-      WEATHER_CACHE_TTL_MS: 1800000,
-      GITHUB_CACHE_TTL_MS: 3600000,
-      TWITTER_CACHE_TTL_MS: 3600000,
-      CODESTATS_CACHE_TTL_MS: 7200000
-    },
-    apiDefaults: {
-      TEMPERATURE: '72°F',
-      WEATHER_DESCRIPTION: 'sunny',
-      WEATHER_EMOJI: '☀️',
-      GITHUB_PUBLIC_REPOS: '10',
-      GITHUB_FOLLOWERS: '5',
-      TWITTER_FOLLOWERS: '100',
-      CODESTATS_XP: '1000'
-    },
-    layout: {
-      FONT_SIZE_PX: 14,
-      LINE_HEIGHT_PX: 20,
-      CHAT_WIDTH_PX: 320,
-      CHAT_HEIGHT_PX: 450,
-      BUBBLE_PAD_X_PX: 12,
-      BUBBLE_PAD_Y_PX: 8,
-      MIN_BUBBLE_W_PX: 40,
-      MAX_BUBBLE_W_PX: 260,
-      BUBBLE_TAIL_HEIGHT_PX: 25,
-      BUBBLE_TAIL_WIDTH_PX: 20,
-      BUBBLE_TAIL_EXT_WIDTH_PX: 26,
-      BUBBLE_TAIL_RADIUS_X: 16,
-      BUBBLE_TAIL_RADIUS_Y: 14,
-      TYPING_DOT_RADIUS_PX: 4,
-      TYPING_CHAR_MS: 40,
-      TYPING_MIN_MS: 1600,
-      TYPING_MAX_MS: 3000,
-      VISIBLE_MESSAGES: 6,
-      STATUS_INDICATOR: {
-        DELIVERED_TEXT: 'Delivered',
-        READ_TEXT: 'Read',
-        FONT_SIZE_PX: 10,
-        COLOR_ME: '#FFFFFF',
-        OFFSET_Y_PX: 10,
-        ANIMATION_DELAY_SEC: 0.2,
-        FADE_IN_DURATION_SEC: 0.3,
-        READ_DELAY_SEC: 1.5,
-        READ_TRANSITION_SEC: 0.2
-      },
-      TIMING: {
-        MIN_READING_TIME_MS: 1000,
-        MS_PER_WORD: 250,
-        READING_RANDOMNESS_MS: 1000,
-        SAME_SENDER_DELAY_MS: 600,
-        SENDER_CHANGE_DELAY_MS: 1800,
-        MESSAGE_VERTICAL_SPACING: 32,
-        BOTTOM_MARGIN: 40,
-        ANIMATION_END_BUFFER_MS: 2000
-      },
-      ANIMATION: {
-        TYPING_BUBBLE_WIDTH: 70,
-        TYPING_BUBBLE_HEIGHT: 36,
-        DOT_ANIMATION_DURATION: 1.4,
-        DOT_DELAY_2: 0.2,
-        DOT_DELAY_3: 0.4,
-        DOT_MIN_OPACITY: 0.4,
-        DOT_MAX_OPACITY: 1.0,
-        DOT_MIN_SCALE: 0.8,
-        DOT_MAX_SCALE: 1.0,
-        BUBBLE_ANIMATION_DURATION: 0.36,
-        BUBBLE_ANIMATION_CURVE: 'ease-in-out',
-        BUBBLE_START_SCALE: 0.8,
-        REACTION_ANIMATION_DURATION_SEC: 0.3,
-        REACTION_ANIMATION_DELAY_FACTOR_SEC: 1.1,
-        CHART_BAR_ANIMATION_DURATION_SEC: 0.8,
-        CHART_ANIMATION_DELAY_SEC: 0.3,
-        SHADOW_BLUR: 1,
-        SHADOW_OFFSET_X: 0,
-        SHADOW_OFFSET_Y: 1,
-        SHADOW_OPACITY: 0.15,
-        SCROLL_DELAY_BUFFER_SEC: 2.2,
-        MIN_SCROLL_DURATION_SEC: 1.2,
-        SCROLL_PIXELS_PER_SEC: 18
-      }
-    },
-    wakatime: {
-      enabled: true,
-      defaults: {
-        wakatime_summary: 'Summary',
-        wakatime_top_language: 'JavaScript',
-        wakatime_top_language_percent: '50'
-      },
-      cacheTtlMs: 7200000
-    }
-  });
+    };
+  }
 
   describe('validateConfiguration', () => {
     it('should validate a correct configuration', () => {
@@ -205,18 +208,16 @@ describe('ConfigValidator', () => {
       expect(result).toBe(true);
     });
 
-    it('should fail when root config is not an object', () => {
+    it('should fail when config is null', () => {
       const result = validateConfiguration(null);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: Root config must be an object.');
     });
 
-    it('should fail when missing required root property', () => {
-      const invalidConfig = createValidConfig();
-      delete invalidConfig.profile;
-      const result = validateConfiguration(invalidConfig);
+    it('should fail when config is not an object', () => {
+      const result = validateConfiguration('invalid');
       expect(result).toBe(false);
-      expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: Missing required property config.profile.');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: Root config must be an object.');
     });
 
     it('should fail when activeTheme does not exist in themes', () => {
@@ -229,7 +230,7 @@ describe('ConfigValidator', () => {
 
     it('should fail when layout FONT_SIZE_PX is not a number', () => {
       const invalidConfig = createValidConfig();
-      invalidConfig.layout.FONT_SIZE_PX = 'not-a-number';
+      invalidConfig.layout.FONT_SIZE_PX = 'invalid';
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.layout.FONT_SIZE_PX must be a number, got string.');
@@ -237,7 +238,7 @@ describe('ConfigValidator', () => {
 
     it('should fail when WORK_START_DATE has invalid year', () => {
       const invalidConfig = createValidConfig();
-      invalidConfig.profile.WORK_START_DATE = { year: 'bad', month: 1, day: 1 };
+      invalidConfig.profile.WORK_START_DATE = { year: 1800, month: 1, day: 1 };
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.profile.WORK_START_DATE.year must be a valid year >= 1900');
@@ -245,7 +246,7 @@ describe('ConfigValidator', () => {
 
     it('should fail when WORK_START_DATE has invalid month', () => {
       const invalidConfig = createValidConfig();
-      invalidConfig.profile.WORK_START_DATE = { year: 2020, month: 99, day: 1 };
+      invalidConfig.profile.WORK_START_DATE = { year: 2020, month: 13, day: 1 };
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.profile.WORK_START_DATE.month must be a valid month (1-12)');
@@ -253,7 +254,7 @@ describe('ConfigValidator', () => {
 
     it('should fail when WORK_START_DATE has invalid day', () => {
       const invalidConfig = createValidConfig();
-      invalidConfig.profile.WORK_START_DATE = { year: 2020, month: 1, day: 99 };
+      invalidConfig.profile.WORK_START_DATE = { year: 2020, month: 1, day: 32 };
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.profile.WORK_START_DATE.day must be a valid day (1-31)');
@@ -275,7 +276,7 @@ describe('ConfigValidator', () => {
 
     it('should fail when hex color is invalid', () => {
       const invalidConfig = createValidConfig();
-      invalidConfig.themes.ios.ME_BUBBLE_COLOR = 'not-a-hex-color';
+      invalidConfig.themes.ios.ME_BUBBLE_COLOR = 'invalid-color';
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('must be a valid hex color'));
@@ -336,7 +337,7 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('must be a string representing a number'));
     });
 
-    // Target specific uncovered lines
+    // Test various null object scenarios
     it('should fail when profile config is null', () => {
       const invalidConfig = createValidConfig();
       invalidConfig.profile = null;
@@ -347,7 +348,7 @@ describe('ConfigValidator', () => {
 
     it('should fail when profile config is not an object', () => {
       const invalidConfig = createValidConfig();
-      invalidConfig.profile = 'not-an-object';
+      invalidConfig.profile = 'invalid';
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.profile must be an object.');
@@ -363,7 +364,7 @@ describe('ConfigValidator', () => {
 
     it('should fail when layout ANIMATION object is not an object', () => {
       const invalidConfig = createValidConfig();
-      invalidConfig.layout.ANIMATION = 'not-an-object';
+      invalidConfig.layout.ANIMATION = 'invalid';
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.layout.ANIMATION must be an object.');
@@ -371,7 +372,7 @@ describe('ConfigValidator', () => {
 
     it('should fail when DOT_ANIMATION_DURATION is not a number', () => {
       const invalidConfig = createValidConfig();
-      invalidConfig.layout.ANIMATION.DOT_ANIMATION_DURATION = 'not-a-number';
+      invalidConfig.layout.ANIMATION.DOT_ANIMATION_DURATION = 'invalid';
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.layout.ANIMATION.DOT_ANIMATION_DURATION must be a number, got string.');
@@ -441,20 +442,11 @@ describe('ConfigValidator', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.apiDefaults must be an object.');
     });
 
-    // NEW TESTS: For weather configuration validation
     it('should validate weather configuration correctly', () => {
       const validConfig = createValidConfig();
       validConfig.weather.enabled = false;
       const result = validateConfiguration(validConfig);
       expect(result).toBe(true);
-    });
-
-    it('should fail when weather config is missing', () => {
-      const invalidConfig = createValidConfig();
-      delete invalidConfig.weather;
-      const result = validateConfiguration(invalidConfig);
-      expect(result).toBe(false);
-      expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: Missing required property config.weather.');
     });
 
     it('should fail when weather.enabled is not a boolean', () => {
@@ -463,6 +455,80 @@ describe('ConfigValidator', () => {
       const result = validateConfiguration(invalidConfig);
       expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.weather.enabled must be a boolean, got string.');
+    });
+
+    it('should validate twitter configuration correctly', () => {
+      const validConfig = createValidConfig();
+      validConfig.twitter.enabled_api_fetch = true;
+      const result = validateConfiguration(validConfig);
+      expect(result).toBe(true);
+    });
+
+    it('should fail when twitter.enabled_api_fetch is not a boolean', () => {
+      const invalidConfig = createValidConfig();
+      invalidConfig.twitter.enabled_api_fetch = 'true';
+      const result = validateConfiguration(invalidConfig);
+      expect(result).toBe(false);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.twitter.enabled_api_fetch must be a boolean, got string.');
+    });
+
+    it('should validate TWITTER_FOLLOWERS as string representing number', () => {
+      const validConfig = createValidConfig();
+      validConfig.profile.TWITTER_FOLLOWERS = '250';
+      const result = validateConfiguration(validConfig);
+      expect(result).toBe(true);
+    });
+
+    it('should allow empty string for TWITTER_FOLLOWERS', () => {
+      const validConfig = createValidConfig();
+      validConfig.profile.TWITTER_FOLLOWERS = '';
+      const result = validateConfiguration(validConfig);
+      expect(result).toBe(true);
+    });
+
+    it('should fail when TWITTER_FOLLOWERS is not a valid number string', () => {
+      const invalidConfig = createValidConfig();
+      invalidConfig.profile.TWITTER_FOLLOWERS = 'not-a-number';
+      const result = validateConfiguration(invalidConfig);
+      expect(result).toBe(false);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.profile.TWITTER_FOLLOWERS must be a string representing a number, got \'not-a-number\'.');
+    });
+
+    it('should validate twitter configuration correctly', () => {
+      const validConfig = createValidConfig();
+      validConfig.twitter.enabled_api_fetch = true;
+      const result = validateConfiguration(validConfig);
+      expect(result).toBe(true);
+    });
+
+    it('should fail when twitter.enabled_api_fetch is not a boolean', () => {
+      const invalidConfig = createValidConfig();
+      invalidConfig.twitter.enabled_api_fetch = 'true';
+      const result = validateConfiguration(invalidConfig);
+      expect(result).toBe(false);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.twitter.enabled_api_fetch must be a boolean, got string.');
+    });
+
+    it('should validate TWITTER_FOLLOWERS as string representing number', () => {
+      const validConfig = createValidConfig();
+      validConfig.profile.TWITTER_FOLLOWERS = '250';
+      const result = validateConfiguration(validConfig);
+      expect(result).toBe(true);
+    });
+
+    it('should allow empty string for TWITTER_FOLLOWERS', () => {
+      const validConfig = createValidConfig();
+      validConfig.profile.TWITTER_FOLLOWERS = '';
+      const result = validateConfiguration(validConfig);
+      expect(result).toBe(true);
+    });
+
+    it('should fail when TWITTER_FOLLOWERS is not a valid number string', () => {
+      const invalidConfig = createValidConfig();
+      invalidConfig.profile.TWITTER_FOLLOWERS = 'not-a-number';
+      const result = validateConfiguration(invalidConfig);
+      expect(result).toBe(false);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Configuration error: config.profile.TWITTER_FOLLOWERS must be a string representing a number, got \'not-a-number\'.');
     });
   });
 });


### PR DESCRIPTION
- Twitter follower count now defaults to manual input due to API costs. Live API fetching is an advanced, explicit opt-in.
- Added 'config.twitter.enabled_api_fetch' (defaults to false).
- Updated twitterDataSource.js to check this flag and token.
- Updated DataService.js to prioritize manual/config follower count.
- Added manual follower input to ProfileEditor.svelte.
- Updated config.js, configStore.js, ConfigValidator.js, and tests.
- Significantly enhanced README.md with clear instructions for AccuWeather Location Key, Code::Stats username, and the new Twitter setup.
- Updated .env.template for Twitter token deprecation.