### PR TITLE
fix(preview-server): strict CORS + CSRF guard + payload/GitHub-target validation (P0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,11 +61,18 @@ coverage
 *.sw?
 .DS_Store
 
-# Repomix
+# Repomix — ignore generated exports, but keep the config tracked so the team can run it
 *repomix*
+!repomix.config.json
+profilechatter-full-export.md
 
-# Docs
+# Docs / internal artifacts — never push these
 ProfileChatter.docx
 
 # Tokens - Do Not Share!
 .tokens/*
+
+# Forensics output + internal planning (may reference unpatched issues)
+.forensics/
+*FORENSICS*
+plans/

--- a/configurator-ui/server/previewServer.js
+++ b/configurator-ui/server/previewServer.js
@@ -27,10 +27,20 @@ import {
 // Network-exposure policy (bind host, debug gating) — pure + unit-tested
 import { resolveBindHost, isExternalBind, isDebugEndpointEnabled } from './serverConfig.js'
 
+// Request-security policy (CORS, CSRF guard, body + GitHub-target validation)
+import {
+  getAllowedOrigins,
+  resolveCorsOrigin,
+  isStateChangingRequestAllowed,
+  validateConfigPayload,
+  validateGithubSaveTarget,
+} from './serverSecurity.js'
+
 // Constants
 const PORT = 3001
 // Default to loopback; LAN exposure is opt-in only (see serverConfig.js).
 const HOST = resolveBindHost(process.env)
+const ALLOWED_ORIGINS = getAllowedOrigins(process.env)
 const FRONTEND_URL = 'http://127.0.0.1:5173'
 const FIVE_MINUTES_SEC = 5 * 60
 const FIVE_MINUTES_MS = FIVE_MINUTES_SEC * 1000
@@ -589,6 +599,16 @@ const routes = {
       logger.debug('Received configuration data with keys:', Object.keys(configJson))
       logger.debug('Config json snippet:', JSON.stringify(configJson).slice(0, 120) + '…')
 
+      // Validate the payload before writing anything to disk
+      const localCheck = validateConfigPayload(configJson)
+      if (!localCheck.valid) {
+        logger.warn('Rejected invalid local-config payload:', localCheck.error)
+        res.statusCode = 400
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ success: false, error: localCheck.error }))
+        return
+      }
+
       // Use the consistent path helper
       const configFilePath = getConfigPath()
 
@@ -679,6 +699,16 @@ const routes = {
         res.statusCode = 400
         res.setHeader('Content-Type', 'application/json')
         res.end(JSON.stringify({ error: 'Missing required fields' }))
+        return
+      }
+
+      // Constrain the write target (repo/path/branch allow-list) before using the token
+      const targetCheck = validateGithubSaveTarget({ repoFullName, filePath, branch })
+      if (!targetCheck.valid) {
+        logger.warn('Rejected disallowed GitHub save target:', targetCheck.error)
+        res.statusCode = 400
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ error: targetCheck.error }))
         return
       }
 
@@ -784,8 +814,12 @@ const server = http.createServer(async (req, res) => {
     const path = parsedUrl.pathname
     const query = parsedUrl.query
 
-    // Set CORS headers
-    res.setHeader('Access-Control-Allow-Origin', '*')
+    // Set CORS headers — echo only the configurator origin, never '*'
+    res.setHeader(
+      'Access-Control-Allow-Origin',
+      resolveCorsOrigin(req.headers.origin, ALLOWED_ORIGINS)
+    )
+    res.setHeader('Vary', 'Origin')
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
 
@@ -795,6 +829,20 @@ const server = http.createServer(async (req, res) => {
       res.statusCode = 204
       res.end()
       return
+    }
+
+    // CSRF guard: reject cross-origin attempts at state-changing / token-backed endpoints
+    const isStateChanging =
+      req.method === 'POST' || (req.method === 'GET' && path === '/api/github/user-repos')
+    if (isStateChanging) {
+      const originCheck = isStateChangingRequestAllowed(req.headers, ALLOWED_ORIGINS)
+      if (!originCheck.allowed) {
+        logger.warn('Blocked cross-origin request:', originCheck.reason, path)
+        res.statusCode = 403
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ error: 'Forbidden: cross-origin request rejected' }))
+        return
+      }
     }
 
     // Route request to appropriate handler

--- a/configurator-ui/server/previewServer.js
+++ b/configurator-ui/server/previewServer.js
@@ -1,182 +1,187 @@
 /**
  * previewServer.js
- * 
+ *
  * A robust server for ProfileChatter SVG generation and OAuth integration.
  * Handles API endpoints, authentication flows, and SVG preview generation.
  */
-import http from 'node:http';
-import { fileURLToPath } from 'node:url';
-import { dirname, join, resolve } from 'node:path';
-import { existsSync, writeFileSync } from 'node:fs';
-import { parse as parseUrl } from 'node:url';
-import { promises as fs } from 'node:fs';
+import http from 'node:http'
+import { fileURLToPath } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+import { existsSync, writeFileSync } from 'node:fs'
+import { parse as parseUrl } from 'node:url'
+import { promises as fs } from 'node:fs'
 
 // Import the config for the API endpoint
-import { config } from '../../src/config/config.js';
+import { config } from '../../src/config/config.js'
 
 // Import OAuth Registry for handling all providers
-import oauthRegistry from '../../src/services/auth/oauthRegistry.js';
+import oauthRegistry from '../../src/services/auth/oauthRegistry.js'
 
 // Import GitHub repository service functions
-import { 
-  getUserWritableRepositories, 
-  checkFileExists, 
-  saveFileToRepo 
-} from '../../src/services/githubRepoService.js';
+import {
+  getUserWritableRepositories,
+  checkFileExists,
+  saveFileToRepo,
+} from '../../src/services/githubRepoService.js'
+
+// Network-exposure policy (bind host, debug gating) — pure + unit-tested
+import { resolveBindHost, isExternalBind, isDebugEndpointEnabled } from './serverConfig.js'
 
 // Constants
-const PORT = 3001;
-const FRONTEND_URL = 'http://127.0.0.1:5173';
-const FIVE_MINUTES_SEC = 5 * 60;
-const FIVE_MINUTES_MS = FIVE_MINUTES_SEC * 1000;
+const PORT = 3001
+// Default to loopback; LAN exposure is opt-in only (see serverConfig.js).
+const HOST = resolveBindHost(process.env)
+const FRONTEND_URL = 'http://127.0.0.1:5173'
+const FIVE_MINUTES_SEC = 5 * 60
+const FIVE_MINUTES_MS = FIVE_MINUTES_SEC * 1000
 
 // Set up paths for importing ProfileChatter
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const projectRoot = resolve(__dirname, '../..');
-const profileChatterPath = join(projectRoot, 'src', 'ProfileChatter.js');
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const projectRoot = resolve(__dirname, '../..')
+const profileChatterPath = join(projectRoot, 'src', 'ProfileChatter.js')
 
 // Define a consistent helper function for configuration file path
 function getConfigPath() {
-  return join(projectRoot, 'profileChatterConfig.json');
+  return join(projectRoot, 'profileChatterConfig.json')
 }
 
 // State store for managing OAuth state parameters securely
 const stateStore = {
   states: new Map(),
-  
+
   add(state) {
-    this.states.set(state, Date.now() + FIVE_MINUTES_MS);
-    setTimeout(() => this.cleanup(), FIVE_MINUTES_MS);
+    this.states.set(state, Date.now() + FIVE_MINUTES_MS)
+    setTimeout(() => this.cleanup(), FIVE_MINUTES_MS)
   },
-  
+
   verify(state) {
-    if (!this.states.has(state)) return false;
-    
-    const expiresAt = this.states.get(state);
-    const isValid = Date.now() < expiresAt;
-    this.states.delete(state);
-    return isValid;
+    if (!this.states.has(state)) return false
+
+    const expiresAt = this.states.get(state)
+    const isValid = Date.now() < expiresAt
+    this.states.delete(state)
+    return isValid
   },
-  
+
   cleanup() {
-    const now = Date.now();
+    const now = Date.now()
     for (const [state, expiresAt] of this.states.entries()) {
-      if (now >= expiresAt) this.states.delete(state);
+      if (now >= expiresAt) this.states.delete(state)
     }
-  }
-};
+  },
+}
 
 // Initialize logger
 const logger = {
   info: (...args) => console.log(`[${new Date().toISOString()}]`, ...args),
   error: (...args) => console.error(`[${new Date().toISOString()}] ERROR:`, ...args),
   warn: (...args) => console.warn(`[${new Date().toISOString()}] WARNING:`, ...args),
-  debug: (...args) => console.log(`[${new Date().toISOString()}] DEBUG:`, ...args)
-};
+  debug: (...args) => console.log(`[${new Date().toISOString()}] DEBUG:`, ...args),
+}
 
 // Utility functions
 function parseCookies(cookieString = '') {
-  const cookies = {};
-  if (!cookieString) return cookies;
-  
-  cookieString.split(';').forEach(cookie => {
-    const parts = cookie.split('=');
+  const cookies = {}
+  if (!cookieString) return cookies
+
+  cookieString.split(';').forEach((cookie) => {
+    const parts = cookie.split('=')
     if (parts.length >= 2) {
-      const key = parts[0].trim();
-      const value = decodeURIComponent(parts[1].trim());
-      cookies[key] = value;
+      const key = parts[0].trim()
+      const value = decodeURIComponent(parts[1].trim())
+      cookies[key] = value
     }
-  });
-  return cookies;
+  })
+  return cookies
 }
 
 function logRequest(req) {
-  logger.info(`${req.method} ${req.url}`);
-  
+  logger.info(`${req.method} ${req.url}`)
+
   const headersToLog = {
     'content-type': req.headers['content-type'],
     'content-length': req.headers['content-length'],
-    'origin': req.headers['origin'],
-    'referer': req.headers['referer']
-  };
-  
-  logger.debug('Headers:', headersToLog);
+    origin: req.headers['origin'],
+    referer: req.headers['referer'],
+  }
+
+  logger.debug('Headers:', headersToLog)
 }
 
 async function parseJsonBody(req) {
   return new Promise((resolve, reject) => {
-    let body = '';
-    
-    req.on('data', chunk => {
-      body += chunk.toString();
-    });
-    
+    let body = ''
+
+    req.on('data', (chunk) => {
+      body += chunk.toString()
+    })
+
     req.on('end', () => {
       try {
-        const data = JSON.parse(body);
-        resolve(data);
+        const data = JSON.parse(body)
+        resolve(data)
       } catch (error) {
-        reject(new Error(`Invalid JSON: ${error.message}`));
+        reject(new Error(`Invalid JSON: ${error.message}`))
       }
-    });
-    
+    })
+
     req.on('error', (error) => {
-      reject(error);
-    });
-  });
+      reject(error)
+    })
+  })
 }
 
 // Load and initialize SVG generator
-logger.info('Initializing server...');
-logger.debug('Current directory:', process.cwd());
-logger.debug('Script directory:', __dirname);
-logger.debug('Project root:', projectRoot);
-logger.debug('Looking for ProfileChatter.js at:', profileChatterPath);
+logger.info('Initializing server...')
+logger.debug('Current directory:', process.cwd())
+logger.debug('Script directory:', __dirname)
+logger.debug('Project root:', projectRoot)
+logger.debug('Looking for ProfileChatter.js at:', profileChatterPath)
 
 if (!existsSync(profileChatterPath)) {
-  logger.error(`File not found at ${profileChatterPath}`);
-  process.exit(1);
+  logger.error(`File not found at ${profileChatterPath}`)
+  process.exit(1)
 }
 
 // Import the main ProfileChatter SVG generator
-let generateChatSVG;
+let generateChatSVG
 try {
-  const profileChatterUrl = `file://${profileChatterPath.replace(/\\/g, '/')}`;
-  logger.debug('Loading module from URL:', profileChatterUrl);
-  
-  const profileChatterModule = await import(profileChatterUrl);
-  generateChatSVG = profileChatterModule.generateChatSVG;
-  logger.info('Successfully imported generateChatSVG function');
+  const profileChatterUrl = `file://${profileChatterPath.replace(/\\/g, '/')}`
+  logger.debug('Loading module from URL:', profileChatterUrl)
+
+  const profileChatterModule = await import(profileChatterUrl)
+  generateChatSVG = profileChatterModule.generateChatSVG
+  logger.info('Successfully imported generateChatSVG function')
 } catch (error) {
-  logger.error('Error importing ProfileChatter module:', error);
-  process.exit(1);
+  logger.error('Error importing ProfileChatter module:', error)
+  process.exit(1)
 }
 
 // Route handlers
 const routes = {
   // Home page with server status
   async handleHomePage(req, res) {
-    logger.info('Serving homepage');
-    res.setHeader('Content-Type', 'text/html');
-    
+    logger.info('Serving homepage')
+    res.setHeader('Content-Type', 'text/html')
+
     // Get OAuth status for all providers
-    const oauthStatus = oauthRegistry.getAuthenticationStatus();
-    let statusHtml = '';
-    
+    const oauthStatus = oauthRegistry.getAuthenticationStatus()
+    let statusHtml = ''
+
     for (const [provider, status] of Object.entries(oauthStatus)) {
-      const color = status.authenticated ? 'green' : 'red';
-      const icon = status.authenticated ? '✅' : '❌';
-      const text = status.authenticated 
+      const color = status.authenticated ? 'green' : 'red'
+      const icon = status.authenticated ? '✅' : '❌'
+      const text = status.authenticated
         ? `${provider} is authenticated`
-        : `${provider} is not authenticated`;
-      const link = status.authenticated 
+        : `${provider} is not authenticated`
+      const link = status.authenticated
         ? ''
-        : ` <a href="/auth/${provider}">Connect ${provider}</a>`;
-      
-      statusHtml += `<p style="color:${color}">${icon} ${text}${link}</p>`;
+        : ` <a href="/auth/${provider}">Connect ${provider}</a>`
+
+      statusHtml += `<p style="color:${color}">${icon} ${text}${link}</p>`
     }
-    
+
     res.end(`
       <html>
         <head>
@@ -217,60 +222,60 @@ const routes = {
           </div>
         </body>
       </html>
-    `);
+    `)
   },
-  
+
   // Start OAuth authorization flow
   async handleOAuthAuthorization(req, res, path) {
-    const providerName = path.substring(6); // extract provider name from path
-    logger.info(`Handling OAuth authorization for provider: ${providerName}`);
-    
+    const providerName = path.substring(6) // extract provider name from path
+    logger.info(`Handling OAuth authorization for provider: ${providerName}`)
+
     if (!providerName) {
-      res.statusCode = 400;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ error: 'Provider name is required' }));
-      return;
+      res.statusCode = 400
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ error: 'Provider name is required' }))
+      return
     }
-    
+
     try {
-      const provider = oauthRegistry.getProvider(providerName);
-      const authUrl = provider.getAuthorizationUrl();
-      
+      const provider = oauthRegistry.getProvider(providerName)
+      const authUrl = provider.getAuthorizationUrl()
+
       // Extract the state parameter from the URL
-      const authUrlObj = new URL(authUrl);
-      const state = authUrlObj.searchParams.get('state');
-      
+      const authUrlObj = new URL(authUrl)
+      const state = authUrlObj.searchParams.get('state')
+
       if (!state) {
-        throw new Error('OAuth state parameter missing from authorization URL');
+        throw new Error('OAuth state parameter missing from authorization URL')
       }
-      
-      logger.info(`Redirecting to ${providerName} authorization URL with state: ${state}`);
-      
+
+      logger.info(`Redirecting to ${providerName} authorization URL with state: ${state}`)
+
       // Store the state in memory instead of cookies
-      stateStore.add(state);
-      
-      res.statusCode = 302;
-      res.setHeader('Location', authUrl);
-      res.end();
+      stateStore.add(state)
+
+      res.statusCode = 302
+      res.setHeader('Location', authUrl)
+      res.end()
     } catch (error) {
-      logger.error(`Error initiating ${providerName} authorization:`, error);
-      res.statusCode = 400;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ error: error.message }));
+      logger.error(`Error initiating ${providerName} authorization:`, error)
+      res.statusCode = 400
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ error: error.message }))
     }
   },
-  
+
   // Handle OAuth callback
   async handleOAuthCallback(req, res, query) {
-    logger.info('Handling OAuth callback');
-    
-    const { code, state, error: oauthError } = query;
-    
+    logger.info('Handling OAuth callback')
+
+    const { code, state, error: oauthError } = query
+
     // Handle OAuth error response
     if (oauthError) {
-      logger.error('OAuth error:', oauthError);
-      res.statusCode = 400;
-      res.setHeader('Content-Type', 'text/html');
+      logger.error('OAuth error:', oauthError)
+      res.statusCode = 400
+      res.setHeader('Content-Type', 'text/html')
       res.end(`
         <html>
           <head><title>Authentication Failed</title></head>
@@ -281,16 +286,16 @@ const routes = {
             <p><a href="${FRONTEND_URL}">Return to application</a></p>
           </body>
         </html>
-      `);
-      return;
+      `)
+      return
     }
 
     // Verify the state parameter using the state store
     if (!state || !stateStore.verify(state)) {
-      logger.error('Invalid or expired state parameter');
-      logger.debug('State from query:', state);
-      res.statusCode = 400;
-      res.setHeader('Content-Type', 'text/html');
+      logger.error('Invalid or expired state parameter')
+      logger.debug('State from query:', state)
+      res.statusCode = 400
+      res.setHeader('Content-Type', 'text/html')
       res.end(`
         <html>
           <head><title>Authentication Failed</title></head>
@@ -300,15 +305,15 @@ const routes = {
             <p><a href="${FRONTEND_URL}">Return to application</a></p>
           </body>
         </html>
-      `);
-      return;
+      `)
+      return
     }
-    
+
     // Ensure authorization code is present
     if (!code) {
-      logger.error('No authorization code provided in callback');
-      res.statusCode = 400;
-      res.setHeader('Content-Type', 'text/html');
+      logger.error('No authorization code provided in callback')
+      res.statusCode = 400
+      res.setHeader('Content-Type', 'text/html')
       res.end(`
         <html>
           <head><title>Authentication Failed</title></head>
@@ -318,27 +323,27 @@ const routes = {
             <p><a href="${FRONTEND_URL}">Return to application</a></p>
           </body>
         </html>
-      `);
-      return;
+      `)
+      return
     }
-    
+
     // Determine which provider to use
-    let provider;
-    let providerName;
-    
+    let provider
+    let providerName
+
     try {
       // If state is provided, use it to determine the provider
-      providerName = oauthRegistry.getProviderFromState(state).providerName;
-      provider = oauthRegistry.getProviderFromState(state);
-      logger.info(`Provider determined from state: ${providerName}`);
-      
+      providerName = oauthRegistry.getProviderFromState(state).providerName
+      provider = oauthRegistry.getProviderFromState(state)
+      logger.info(`Provider determined from state: ${providerName}`)
+
       // Exchange code for tokens
-      await provider.exchangeCodeForTokens(code);
-      logger.info(`Successfully authenticated with ${providerName}`);
-      
+      await provider.exchangeCodeForTokens(code)
+      logger.info(`Successfully authenticated with ${providerName}`)
+
       // Send success response
-      res.statusCode = 200;
-      res.setHeader('Content-Type', 'text/html');
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/html')
       res.end(`
         <html>
           <head>
@@ -357,15 +362,15 @@ const routes = {
             <a href="${FRONTEND_URL}" class="button">Return to Application</a>
           </body>
         </html>
-      `);
+      `)
     } catch (error) {
-      logger.error('Error during OAuth callback:', error);
-      
+      logger.error('Error during OAuth callback:', error)
+
       // Determine provider name for the error message
-      providerName = providerName || 'service';
-      
-      res.statusCode = 500;
-      res.setHeader('Content-Type', 'text/html');
+      providerName = providerName || 'service'
+
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'text/html')
       res.end(`
         <html>
           <head><title>Authentication Failed</title></head>
@@ -375,187 +380,199 @@ const routes = {
             <p><a href="/auth/${providerName.toLowerCase()}">Try again</a> or <a href="${FRONTEND_URL}">return to application</a></p>
           </body>
         </html>
-      `);
+      `)
     }
   },
-  
+
   // OAuth status endpoint
   async handleOAuthStatus(req, res) {
-    logger.info('Handling GET request to /oauth-status');
-    
-    const status = oauthRegistry.getAuthenticationStatus();
-    
-    res.statusCode = 200;
-    res.setHeader('Content-Type', 'application/json');
-    res.end(JSON.stringify(status));
+    logger.info('Handling GET request to /oauth-status')
+
+    const status = oauthRegistry.getAuthenticationStatus()
+
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify(status))
   },
-  
+
   // Configuration data API
   async handleConfigData(req, res) {
-    logger.info('Handling GET request to /api/initial-config-data');
-    
+    logger.info('Handling GET request to /api/initial-config-data')
+
     // Get the path to the config file
-    const configFilePath = getConfigPath();
-    
+    const configFilePath = getConfigPath()
+
     try {
       // Check if the config file exists
       if (existsSync(configFilePath)) {
         try {
           // Read and parse the saved configuration
-          const fileContent = await fs.readFile(configFilePath, 'utf8');
-          const savedConfig = JSON.parse(fileContent);
-          
-          logger.info(`Loaded saved configuration from ${configFilePath}`);
-          res.statusCode = 200;
-          res.setHeader('Content-Type', 'application/json');
-          res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-          res.setHeader('Pragma', 'no-cache');
-          res.end(JSON.stringify(savedConfig));
-          return;
+          const fileContent = await fs.readFile(configFilePath, 'utf8')
+          const savedConfig = JSON.parse(fileContent)
+
+          logger.info(`Loaded saved configuration from ${configFilePath}`)
+          res.statusCode = 200
+          res.setHeader('Content-Type', 'application/json')
+          res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+          res.setHeader('Pragma', 'no-cache')
+          res.end(JSON.stringify(savedConfig))
+          return
         } catch (readErr) {
-          logger.warn(`Corrupt JSON in ${configFilePath}:`, readErr.message);
+          logger.warn(`Corrupt JSON in ${configFilePath}:`, readErr.message)
           // Falls through to default config
         }
       } else {
-        logger.info(`No saved config found at ${configFilePath}, using defaults`);
+        logger.info(`No saved config found at ${configFilePath}, using defaults`)
       }
-      
+
       // Return a minimal valid configuration structure that will pass validation
       const emptyConfig = {
-        profile: { 
+        profile: {
           NAME: 'Your Name',
           PROFESSION: 'Your Profession',
           LOCATION: 'Your City',
           COMPANY: 'Your Company',
           GITHUB_USERNAME: 'your_github',
-          TIMEZONE: 'UTC'
+          TIMEZONE: 'UTC',
         },
         chatMessages: [],
         activeTheme: config.activeTheme,
         avatars: config.avatars,
         themes: config.themes,
         fontOptions: config.fontOptions,
-        layout: config.layout
-      };
-      
-      res.statusCode = 200;
-      res.setHeader('Content-Type', 'application/json');
-      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-      res.setHeader('Pragma', 'no-cache');
-      res.end(JSON.stringify(emptyConfig));
-      
-      logger.info('Default config data sent due to missing or invalid saved config');
+        layout: config.layout,
+      }
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+      res.setHeader('Pragma', 'no-cache')
+      res.end(JSON.stringify(emptyConfig))
+
+      logger.info('Default config data sent due to missing or invalid saved config')
     } catch (error) {
-      logger.error('Error handling configuration request:', error);
-      
+      logger.error('Error handling configuration request:', error)
+
       // Fall back to defaults in case of any other error
       const emptyConfig = {
-        profile: { 
+        profile: {
           NAME: 'Your Name',
           PROFESSION: 'Your Profession',
           LOCATION: 'Your City',
           COMPANY: 'Your Company',
           GITHUB_USERNAME: 'your_github',
-          TIMEZONE: 'UTC'
+          TIMEZONE: 'UTC',
         },
         chatMessages: [],
-        activeTheme: config.activeTheme
-      };
-      
-      res.statusCode = 200;
-      res.setHeader('Content-Type', 'application/json');
-      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-      res.setHeader('Pragma', 'no-cache');
-      res.end(JSON.stringify(emptyConfig));
-      
-      logger.info('Default config data sent due to error');
+        activeTheme: config.activeTheme,
+      }
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+      res.setHeader('Pragma', 'no-cache')
+      res.end(JSON.stringify(emptyConfig))
+
+      logger.info('Default config data sent due to error')
     }
   },
-  
+
   // SVG generation endpoint
   async handleSvgGeneration(req, res) {
-    logger.info('Handling POST request to /generate-preview');
-    
+    logger.info('Handling POST request to /generate-preview')
+
     try {
-      const configData = await parseJsonBody(req);
-      logger.debug('Parsed JSON data with keys:', Object.keys(configData));
-      
-      if (!configData.profile || !configData.activeTheme || !Array.isArray(configData.chatMessages)) {
-        logger.error('Invalid configuration data received');
-        res.statusCode = 400;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ 
-          error: 'Invalid configuration data. Must include profile, activeTheme, and chatMessages array.',
-          received: {
-            hasProfile: !!configData.profile,
-            activeTheme: configData.activeTheme,
-            chatMessagesIsArray: Array.isArray(configData.chatMessages),
-            chatMessagesLength: Array.isArray(configData.chatMessages) ? configData.chatMessages.length : 'N/A'
-          }
-        }));
-        return;
+      const configData = await parseJsonBody(req)
+      logger.debug('Parsed JSON data with keys:', Object.keys(configData))
+
+      if (
+        !configData.profile ||
+        !configData.activeTheme ||
+        !Array.isArray(configData.chatMessages)
+      ) {
+        logger.error('Invalid configuration data received')
+        res.statusCode = 400
+        res.setHeader('Content-Type', 'application/json')
+        res.end(
+          JSON.stringify({
+            error:
+              'Invalid configuration data. Must include profile, activeTheme, and chatMessages array.',
+            received: {
+              hasProfile: !!configData.profile,
+              activeTheme: configData.activeTheme,
+              chatMessagesIsArray: Array.isArray(configData.chatMessages),
+              chatMessagesLength: Array.isArray(configData.chatMessages)
+                ? configData.chatMessages.length
+                : 'N/A',
+            },
+          })
+        )
+        return
       }
-      
+
       // Extract work start date from the received profile
-      const workStartDate = configData.profile.WORK_START_DATE;
-      const workStartObj = workStartDate ? { ...workStartDate } : null;
-      delete configData.profile.WORK_START_DATE; // Remove from profile since it's handled separately
-      
+      const workStartDate = configData.profile.WORK_START_DATE
+      const workStartObj = workStartDate ? { ...workStartDate } : null
+      delete configData.profile.WORK_START_DATE // Remove from profile since it's handled separately
+
       // Prepare custom context for SVG generation
       const customContext = {
         profile: configData.profile,
         activeTheme: configData.activeTheme,
         chatMessages: configData.chatMessages,
-        workStartDate: workStartObj ? new Date(workStartObj.year, workStartObj.month - 1, workStartObj.day) : null,
+        workStartDate: workStartObj
+          ? new Date(workStartObj.year, workStartObj.month - 1, workStartObj.day)
+          : null,
         avatars: configData.avatars,
         themeOverrides: configData.themeOverrides || null,
-        layoutAnimationOverrides: configData.layoutAnimationOverrides || null
-      };
-      
+        layoutAnimationOverrides: configData.layoutAnimationOverrides || null,
+      }
+
       // Log configuration details
       if (customContext.avatars) {
         logger.debug('Avatar configuration received:', {
           enabled: customContext.avatars.enabled,
           shape: customContext.avatars.shape,
           hasMeConfig: !!customContext.avatars.me,
-          hasVisitorConfig: !!customContext.avatars.visitor
-        });
+          hasVisitorConfig: !!customContext.avatars.visitor,
+        })
       }
-      
+
       if (customContext.themeOverrides) {
-        logger.debug('Theme overrides received for theme:', customContext.activeTheme);
+        logger.debug('Theme overrides received for theme:', customContext.activeTheme)
       }
 
       if (customContext.layoutAnimationOverrides) {
-        logger.debug('Layout animation overrides received:', 
-          JSON.stringify(customContext.layoutAnimationOverrides));
+        logger.debug(
+          'Layout animation overrides received:',
+          JSON.stringify(customContext.layoutAnimationOverrides)
+        )
       }
-      
-      logger.info('Generating SVG with custom context...');
-      logger.debug('Profile:', JSON.stringify(customContext.profile).substring(0, 100) + '...');
-      logger.debug('Theme:', customContext.activeTheme);
-      logger.debug('Chat messages count:', customContext.chatMessages.length);
-      logger.debug('Work start date:', customContext.workStartDate);
-      
+
+      logger.info('Generating SVG with custom context...')
+      logger.debug('Profile:', JSON.stringify(customContext.profile).substring(0, 100) + '...')
+      logger.debug('Theme:', customContext.activeTheme)
+      logger.debug('Chat messages count:', customContext.chatMessages.length)
+      logger.debug('Work start date:', customContext.workStartDate)
+
       // Generate SVG
-      const svgMarkup = await generateChatSVG(customContext);
-      logger.info('SVG generated, length:', svgMarkup.length);
-      
+      const svgMarkup = await generateChatSVG(customContext)
+      logger.info('SVG generated, length:', svgMarkup.length)
+
       // Send SVG response
-      res.statusCode = 200;
-      res.setHeader('Content-Type', 'image/svg+xml');
-      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-      res.setHeader('Pragma', 'no-cache');
-      res.setHeader('Expires', '0');
-      res.setHeader('Surrogate-Control', 'no-store');
-      res.end(svgMarkup);
-      logger.info('SVG sent successfully');
-      
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'image/svg+xml')
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+      res.setHeader('Pragma', 'no-cache')
+      res.setHeader('Expires', '0')
+      res.setHeader('Surrogate-Control', 'no-store')
+      res.end(svgMarkup)
+      logger.info('SVG sent successfully')
     } catch (error) {
-      logger.error('Error processing request:', error);
-      res.statusCode = 500;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ error: `Error generating SVG: ${error.message}` }));
+      logger.error('Error processing request:', error)
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ error: `Error generating SVG: ${error.message}` }))
     }
   },
 
@@ -564,81 +581,89 @@ const routes = {
    * @async
    */
   async handleSaveLocalConfig(req, res) {
-    logger.info('Handling POST request to /api/save-local-config');
-    
+    logger.info('Handling POST request to /api/save-local-config')
+
     try {
       // Parse the request body
-      const configJson = await parseJsonBody(req);
-      logger.debug('Received configuration data with keys:', Object.keys(configJson));
-      logger.debug('Config json snippet:', JSON.stringify(configJson).slice(0, 120) + '…');
-      
+      const configJson = await parseJsonBody(req)
+      logger.debug('Received configuration data with keys:', Object.keys(configJson))
+      logger.debug('Config json snippet:', JSON.stringify(configJson).slice(0, 120) + '…')
+
       // Use the consistent path helper
-      const configFilePath = getConfigPath();
-      
+      const configFilePath = getConfigPath()
+
       // Save the configuration to the file system
       try {
-        writeFileSync(configFilePath, JSON.stringify(configJson, null, 2));
-        logger.info(`Successfully saved configuration to ${configFilePath}`);
-        
+        writeFileSync(configFilePath, JSON.stringify(configJson, null, 2))
+        logger.info(`Successfully saved configuration to ${configFilePath}`)
+
         // Return success response
-        res.statusCode = 200;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ 
-          success: true, 
-          message: 'Local config saved.',
-          path: configFilePath
-        }));
+        res.statusCode = 200
+        res.setHeader('Content-Type', 'application/json')
+        res.end(
+          JSON.stringify({
+            success: true,
+            message: 'Local config saved.',
+            path: configFilePath,
+          })
+        )
       } catch (fileError) {
-        throw new Error(`Failed to write file: ${fileError.message}`);
+        throw new Error(`Failed to write file: ${fileError.message}`)
       }
     } catch (error) {
-      logger.error('Error saving local config:', error);
-      res.statusCode = 500;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ 
-        success: false, 
-        error: `Failed to save local config: ${error.message}` 
-      }));
+      logger.error('Error saving local config:', error)
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify({
+          success: false,
+          error: `Failed to save local config: ${error.message}`,
+        })
+      )
     }
   },
 
   // GitHub repository listing endpoint
   async handleGithubUserRepos(req, res) {
-    logger.info('Handling GET request to /api/github/user-repos');
-    
+    logger.info('Handling GET request to /api/github/user-repos')
+
     try {
       // Ensure user has a valid GitHub OAuth token
-      const githubProvider = oauthRegistry.getProvider('github');
-      const accessToken = await githubProvider.getAccessToken();
-      
+      const githubProvider = oauthRegistry.getProvider('github')
+      const accessToken = await githubProvider.getAccessToken()
+
       // Get the list of repositories the user can write to
-      const repositories = await getUserWritableRepositories(accessToken);
-      
+      const repositories = await getUserWritableRepositories(accessToken)
+
       // Return the repository list as JSON
-      res.statusCode = 200;
-      res.setHeader('Content-Type', 'application/json');
-      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
-      res.end(JSON.stringify(repositories));
-      logger.info(`Successfully fetched ${repositories.length} writable repositories`);
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+      res.end(JSON.stringify(repositories))
+      logger.info(`Successfully fetched ${repositories.length} writable repositories`)
     } catch (error) {
-      logger.error('Error fetching GitHub repositories:', error);
-      
+      logger.error('Error fetching GitHub repositories:', error)
+
       // Determine if this is an authentication error
-      const isAuthError = error.message.includes('No valid GitHub token') || 
-                          error.message.includes('authentication');
-      
-      res.statusCode = isAuthError ? 401 : 500;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ 
-        error: isAuthError ? 'GitHub authentication required' : `Error fetching repositories: ${error.message}`
-      }));
+      const isAuthError =
+        error.message.includes('No valid GitHub token') || error.message.includes('authentication')
+
+      res.statusCode = isAuthError ? 401 : 500
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify({
+          error: isAuthError
+            ? 'GitHub authentication required'
+            : `Error fetching repositories: ${error.message}`,
+        })
+      )
     }
   },
 
   // GitHub save config endpoint
   async handleGithubSaveConfig(req, res) {
-    logger.info('Handling POST request to /api/github/save-config');
-    
+    logger.info('Handling POST request to /api/github/save-config')
+
     try {
       // Parse the request body
       const {
@@ -646,42 +671,44 @@ const routes = {
         filePath,
         commitMessage,
         configContent,
-        branch = 'main'
-      } = await parseJsonBody(req);
-      
+        branch = 'main',
+      } = await parseJsonBody(req)
+
       // Validate required fields
       if (!repoFullName || !filePath || !commitMessage || !configContent) {
-        res.statusCode = 400;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ error: 'Missing required fields' }));
-        return;
+        res.statusCode = 400
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ error: 'Missing required fields' }))
+        return
       }
-      
+
       // Parse repository owner and name
-      const [owner, repo] = repoFullName.split('/');
+      const [owner, repo] = repoFullName.split('/')
       if (!owner || !repo) {
-        throw new Error('Invalid repository name format. Expected "owner/repo"');
+        throw new Error('Invalid repository name format. Expected "owner/repo"')
       }
-      
+
       // Get GitHub access token
-      const githubProvider = oauthRegistry.getProvider('github');
-      let accessToken;
-      
+      const githubProvider = oauthRegistry.getProvider('github')
+      let accessToken
+
       try {
-        accessToken = await githubProvider.getAccessToken();
+        accessToken = await githubProvider.getAccessToken()
       } catch (authError) {
-        logger.error('GitHub authentication required:', authError);
-        res.statusCode = 401;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ error: 'GitHub authentication required' }));
-        return;
+        logger.error('GitHub authentication required:', authError)
+        res.statusCode = 401
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ error: 'GitHub authentication required' }))
+        return
       }
-      
-      logger.info(`Saving config to GitHub repo: ${owner}/${repo}, path: ${filePath}, branch: ${branch}`);
-      
+
+      logger.info(
+        `Saving config to GitHub repo: ${owner}/${repo}, path: ${filePath}, branch: ${branch}`
+      )
+
       // Check if the file already exists
-      const { exists, sha } = await checkFileExists(accessToken, owner, repo, filePath, branch);
-      
+      const { exists, sha } = await checkFileExists(accessToken, owner, repo, filePath, branch)
+
       // Save the file to the repo (create or update)
       const result = await saveFileToRepo(
         accessToken,
@@ -692,165 +719,187 @@ const routes = {
         commitMessage,
         branch,
         exists ? sha : null
-      );
-      
+      )
+
       // Return success response
-      res.statusCode = 200;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({
-        success: true,
-        commitUrl: result.commitUrl,
-        fileUrl: result.content?.html_url || null
-      }));
-      
-      logger.info(`Successfully saved config to GitHub: ${result.commitUrl}`);
-      
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'application/json')
+      res.end(
+        JSON.stringify({
+          success: true,
+          commitUrl: result.commitUrl,
+          fileUrl: result.content?.html_url || null,
+        })
+      )
+
+      logger.info(`Successfully saved config to GitHub: ${result.commitUrl}`)
     } catch (error) {
-      logger.error('Error saving config to GitHub:', error);
-      
-      const isAuthError = error.message.includes('authentication') || error.message.includes('token');
-      res.statusCode = isAuthError ? 401 : 500;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ error: error.message }));
+      logger.error('Error saving config to GitHub:', error)
+
+      const isAuthError =
+        error.message.includes('authentication') || error.message.includes('token')
+      res.statusCode = isAuthError ? 401 : 500
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ error: error.message }))
     }
   },
-  
+
   // Debug cookies endpoint
   async handleDebugCookies(req, res) {
-    logger.info('Debugging cookies and state store');
-    res.setHeader('Content-Type', 'application/json');
-    
-    const cookies = parseCookies(req.headers.cookie);
-    const stateCount = stateStore.states.size;
+    logger.info('Debugging cookies and state store')
+    res.setHeader('Content-Type', 'application/json')
+
+    const cookies = parseCookies(req.headers.cookie)
+    const stateCount = stateStore.states.size
     const stateEntries = Array.from(stateStore.states.entries()).map(([state, expires]) => ({
       state: state.substring(0, 10) + '...',
-      expiresIn: Math.floor((expires - Date.now()) / 1000) + ' seconds'
-    }));
-    
-    res.end(JSON.stringify({
-      rawCookieHeader: req.headers.cookie,
-      parsedCookies: cookies,
-      stateStore: {
-        count: stateCount,
-        entries: stateEntries
-      },
-      currentTime: new Date().toISOString()
-    }, null, 2));
-  }
-};
+      expiresIn: Math.floor((expires - Date.now()) / 1000) + ' seconds',
+    }))
+
+    res.end(
+      JSON.stringify(
+        {
+          rawCookieHeader: req.headers.cookie,
+          parsedCookies: cookies,
+          stateStore: {
+            count: stateCount,
+            entries: stateEntries,
+          },
+          currentTime: new Date().toISOString(),
+        },
+        null,
+        2
+      )
+    )
+  },
+}
 
 // Create HTTP server with request handler
 const server = http.createServer(async (req, res) => {
   try {
-    logRequest(req);
-    
+    logRequest(req)
+
     // Parse URL for path and query parameters
-    const parsedUrl = parseUrl(req.url, true);
-    const path = parsedUrl.pathname;
-    const query = parsedUrl.query;
-    
+    const parsedUrl = parseUrl(req.url, true)
+    const path = parsedUrl.pathname
+    const query = parsedUrl.query
+
     // Set CORS headers
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-    
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
     // Handle preflight request
     if (req.method === 'OPTIONS') {
-      logger.info('Handling OPTIONS preflight request');
-      res.statusCode = 204;
-      res.end();
-      return;
+      logger.info('Handling OPTIONS preflight request')
+      res.statusCode = 204
+      res.end()
+      return
     }
-    
+
     // Route request to appropriate handler
     if (req.method === 'GET') {
       if (path === '/' || path === '') {
-        await routes.handleHomePage(req, res);
+        await routes.handleHomePage(req, res)
       } else if (path.startsWith('/auth/')) {
-        await routes.handleOAuthAuthorization(req, res, path);
+        await routes.handleOAuthAuthorization(req, res, path)
       } else if (path === '/callback' || path.startsWith('/callback/')) {
-        await routes.handleOAuthCallback(req, res, query, path);
+        await routes.handleOAuthCallback(req, res, query, path)
       } else if (path === '/oauth-status') {
-        await routes.handleOAuthStatus(req, res);
+        await routes.handleOAuthStatus(req, res)
       } else if (path === '/api/initial-config-data') {
-        await routes.handleConfigData(req, res);
+        await routes.handleConfigData(req, res)
       } else if (path === '/api/github/user-repos') {
-        await routes.handleGithubUserRepos(req, res);
-      } else if (path === '/debug-cookies') {
-        await routes.handleDebugCookies(req, res);
+        await routes.handleGithubUserRepos(req, res)
+      } else if (path === '/debug-cookies' && isDebugEndpointEnabled(process.env)) {
+        await routes.handleDebugCookies(req, res)
       } else {
         // Not found
-        logger.info('Invalid endpoint requested:', req.method, path);
-        res.statusCode = 404;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ error: 'Endpoint not found', method: req.method, url: req.url }));
+        logger.info('Invalid endpoint requested:', req.method, path)
+        res.statusCode = 404
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ error: 'Endpoint not found', method: req.method, url: req.url }))
       }
     } else if (req.method === 'POST') {
-      if (path === '/generate-preview' || path === '/generate-preview/' || path.startsWith('/generate-preview?')) {
-        await routes.handleSvgGeneration(req, res);
+      if (
+        path === '/generate-preview' ||
+        path === '/generate-preview/' ||
+        path.startsWith('/generate-preview?')
+      ) {
+        await routes.handleSvgGeneration(req, res)
       } else if (path === '/api/github/save-config') {
-        await routes.handleGithubSaveConfig(req, res);
+        await routes.handleGithubSaveConfig(req, res)
       } else if (path === '/api/save-local-config') {
-        await routes.handleSaveLocalConfig(req, res);
+        await routes.handleSaveLocalConfig(req, res)
       } else {
         // Not found
-        logger.info('Invalid endpoint requested:', req.method, path);
-        res.statusCode = 404;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify({ error: 'Endpoint not found', method: req.method, url: req.url }));
+        logger.info('Invalid endpoint requested:', req.method, path)
+        res.statusCode = 404
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ error: 'Endpoint not found', method: req.method, url: req.url }))
       }
     } else {
       // Method not allowed
-      logger.info('Method not allowed:', req.method, path);
-      res.statusCode = 405;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ error: 'Method not allowed', method: req.method, url: req.url }));
+      logger.info('Method not allowed:', req.method, path)
+      res.statusCode = 405
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ error: 'Method not allowed', method: req.method, url: req.url }))
     }
   } catch (serverError) {
     // Catch-all error handler
-    logger.error('Unhandled server error:', serverError);
+    logger.error('Unhandled server error:', serverError)
     try {
-      res.statusCode = 500;
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ error: 'Internal server error' }));
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ error: 'Internal server error' }))
     } catch (responseError) {
-      logger.error('Error sending error response:', responseError);
+      logger.error('Error sending error response:', responseError)
     }
   }
-});
+})
 
 // Server lifecycle management
-server.listen(PORT, () => {
-  logger.info(`Preview server running at http://127.0.0.1:${PORT}`);
-  logger.info(`Serving endpoints:`);
-  logger.info(`- GET / - Homepage`);
-  logger.info(`- GET /api/initial-config-data - Configuration API`);
-  logger.info(`- POST /generate-preview - SVG generation`);
-  logger.info(`- POST /api/save-local-config - Save configuration to local filesystem`);
-  logger.info(`- GET /auth/{provider} - Initiate OAuth flow for a provider`);
-  logger.info(`- GET /callback - Unified OAuth callback`);
-  logger.info(`- GET /oauth-status - Check OAuth authentication status`);
-  logger.info(`- GET /api/github/user-repos - Get user's writable GitHub repositories`);
-  logger.info(`- POST /api/github/save-config - Save configuration to GitHub repository`);
-  logger.info(`- GET /debug-cookies - Debug state and cookies`);
-});
+server.listen(PORT, HOST, () => {
+  logger.info(`Preview server running at http://${HOST}:${PORT}`)
+  if (isExternalBind(HOST)) {
+    logger.warn('================================================================')
+    logger.warn(`SECURITY: preview server is bound to ${HOST} and is reachable from your LAN.`)
+    logger.warn('Its endpoints are UNAUTHENTICATED and can commit to your GitHub repos')
+    logger.warn('using your stored token. Only run this on a fully trusted network.')
+    logger.warn('Unset PREVIEW_ALLOW_EXTERNAL / PREVIEW_SERVER_HOST to bind loopback-only.')
+    logger.warn('================================================================')
+  }
+  logger.info(`Serving endpoints:`)
+  logger.info(`- GET / - Homepage`)
+  logger.info(`- GET /api/initial-config-data - Configuration API`)
+  logger.info(`- POST /generate-preview - SVG generation`)
+  logger.info(`- POST /api/save-local-config - Save configuration to local filesystem`)
+  logger.info(`- GET /auth/{provider} - Initiate OAuth flow for a provider`)
+  logger.info(`- GET /callback - Unified OAuth callback`)
+  logger.info(`- GET /oauth-status - Check OAuth authentication status`)
+  logger.info(`- GET /api/github/user-repos - Get user's writable GitHub repositories`)
+  logger.info(`- POST /api/github/save-config - Save configuration to GitHub repository`)
+  if (isDebugEndpointEnabled(process.env)) {
+    logger.info(`- GET /debug-cookies - Debug state and cookies (DEBUG MODE ENABLED)`)
+  }
+})
 
 server.on('error', (error) => {
-  logger.error('Server error:', error);
+  logger.error('Server error:', error)
   if (error.code === 'EADDRINUSE') {
-    logger.error(`Port ${PORT} is already in use. Please choose a different port.`);
+    logger.error(`Port ${PORT} is already in use. Please choose a different port.`)
   }
-  process.exit(1);
-});
+  process.exit(1)
+})
 
 process.on('SIGINT', () => {
-  logger.info('Shutting down preview server...');
+  logger.info('Shutting down preview server...')
   server.close(() => {
-    logger.info('Preview server stopped');
-    process.exit(0);
-  });
-});
+    logger.info('Preview server stopped')
+    process.exit(0)
+  })
+})
 
 process.on('unhandledRejection', (reason) => {
-  logger.error('Unhandled Promise Rejection:', reason);
-});
+  logger.error('Unhandled Promise Rejection:', reason)
+})

--- a/configurator-ui/server/serverConfig.js
+++ b/configurator-ui/server/serverConfig.js
@@ -1,0 +1,62 @@
+/**
+ * serverConfig.js
+ *
+ * Pure, side-effect-free helpers for the preview server's network-exposure
+ * policy. Kept separate from previewServer.js so the bind/security decisions
+ * can be unit-tested without starting an HTTP server.
+ *
+ * Security note: the preview server exposes unauthenticated, state-changing
+ * endpoints (including GitHub writes using the developer's stored token), so it
+ * must bind to loopback by default and only reach the LAN on explicit opt-in.
+ */
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on'])
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost'])
+
+function isTruthy(value) {
+  return typeof value === 'string' && TRUTHY.has(value.trim().toLowerCase())
+}
+
+/**
+ * Decide which host the preview server binds to.
+ * Defaults to loopback (127.0.0.1) so the server is NOT reachable from the LAN.
+ * External binding must be explicitly opted into.
+ *
+ * @param {Record<string, string | undefined>} [env] - environment variables
+ * @returns {string} the host to pass to server.listen()
+ */
+export function resolveBindHost(env = {}) {
+  const explicitHost = env.PREVIEW_SERVER_HOST
+  if (typeof explicitHost === 'string' && explicitHost.trim() !== '') {
+    return explicitHost.trim()
+  }
+  if (isTruthy(env.PREVIEW_ALLOW_EXTERNAL)) {
+    return '0.0.0.0'
+  }
+  return '127.0.0.1'
+}
+
+/**
+ * Whether a host represents a LAN-reachable (non-loopback) bind. Used to emit a
+ * loud security warning when the server is intentionally exposed.
+ *
+ * @param {string | undefined | null} host
+ * @returns {boolean}
+ */
+export function isExternalBind(host) {
+  if (host == null || host === '') {
+    return true // empty host binds every interface
+  }
+  return !LOOPBACK_HOSTS.has(host)
+}
+
+/**
+ * Whether debug endpoints (e.g. /debug-cookies) are enabled. Disabled by
+ * default; opt-in only.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {boolean}
+ */
+export function isDebugEndpointEnabled(env = {}) {
+  return isTruthy(env.PREVIEW_ENABLE_DEBUG)
+}

--- a/configurator-ui/server/serverConfig.test.js
+++ b/configurator-ui/server/serverConfig.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { resolveBindHost, isExternalBind, isDebugEndpointEnabled } from './serverConfig.js'
+
+describe('preview server bind-host policy (security)', () => {
+  it('defaults to loopback (127.0.0.1) when no host env is set', () => {
+    expect(resolveBindHost({})).toBe('127.0.0.1')
+  })
+
+  it('does NOT resolve to an all-interfaces bind by default', () => {
+    expect(isExternalBind(resolveBindHost({}))).toBe(false)
+  })
+
+  it('binds all interfaces only when external access is explicitly opted in', () => {
+    expect(resolveBindHost({ PREVIEW_ALLOW_EXTERNAL: 'true' })).toBe('0.0.0.0')
+  })
+
+  it('honors an explicit custom host', () => {
+    expect(resolveBindHost({ PREVIEW_SERVER_HOST: '192.168.1.50' })).toBe('192.168.1.50')
+  })
+
+  it('ignores a blank PREVIEW_SERVER_HOST and stays loopback', () => {
+    expect(resolveBindHost({ PREVIEW_SERVER_HOST: '   ' })).toBe('127.0.0.1')
+  })
+})
+
+describe('isExternalBind classifies LAN-reachable hosts', () => {
+  it('treats 0.0.0.0, ::, and a specific LAN IP as external', () => {
+    expect(isExternalBind('0.0.0.0')).toBe(true)
+    expect(isExternalBind('::')).toBe(true)
+    expect(isExternalBind('192.168.1.50')).toBe(true)
+  })
+
+  it('treats loopback hosts as not external', () => {
+    expect(isExternalBind('127.0.0.1')).toBe(false)
+    expect(isExternalBind('::1')).toBe(false)
+    expect(isExternalBind('localhost')).toBe(false)
+  })
+
+  it('treats an empty/undefined host as external (binds everything)', () => {
+    expect(isExternalBind('')).toBe(true)
+    expect(isExternalBind(undefined)).toBe(true)
+  })
+})
+
+describe('debug endpoint gating (security)', () => {
+  it('disables /debug-cookies by default', () => {
+    expect(isDebugEndpointEnabled({})).toBe(false)
+  })
+
+  it('enables debug endpoints only when explicitly turned on', () => {
+    expect(isDebugEndpointEnabled({ PREVIEW_ENABLE_DEBUG: 'true' })).toBe(true)
+  })
+})

--- a/configurator-ui/server/serverSecurity.js
+++ b/configurator-ui/server/serverSecurity.js
@@ -1,0 +1,153 @@
+/**
+ * serverSecurity.js
+ *
+ * Pure, side-effect-free request-security helpers for the preview server:
+ * CORS origin policy, cross-origin (CSRF) enforcement for state-changing
+ * endpoints, request-body validation, and a GitHub write target allow-list.
+ *
+ * Kept separate from previewServer.js so the security decisions can be
+ * unit-tested without an HTTP server.
+ */
+
+const DEFAULT_ALLOWED_ORIGINS = ['http://127.0.0.1:5173', 'http://localhost:5173']
+
+/**
+ * The origins permitted to call the preview server (the local configurator).
+ * Overridable via PREVIEW_ALLOWED_ORIGINS (comma-separated).
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {string[]}
+ */
+export function getAllowedOrigins(env = {}) {
+  const override = env.PREVIEW_ALLOWED_ORIGINS
+  if (typeof override === 'string' && override.trim() !== '') {
+    return override
+      .split(',')
+      .map((o) => o.trim())
+      .filter(Boolean)
+  }
+  return [...DEFAULT_ALLOWED_ORIGINS]
+}
+
+/**
+ * @param {string | undefined | null} origin
+ * @param {string[]} allowedOrigins
+ * @returns {boolean}
+ */
+export function isOriginAllowed(origin, allowedOrigins) {
+  return typeof origin === 'string' && allowedOrigins.includes(origin)
+}
+
+/**
+ * The value to send in Access-Control-Allow-Origin. Echoes the request origin
+ * when allowed; otherwise falls back to the primary allowed origin so a foreign
+ * origin can never read responses. Never returns '*'.
+ * @param {string | undefined | null} requestOrigin
+ * @param {string[]} allowedOrigins
+ * @returns {string}
+ */
+export function resolveCorsOrigin(requestOrigin, allowedOrigins) {
+  return isOriginAllowed(requestOrigin, allowedOrigins) ? requestOrigin : allowedOrigins[0]
+}
+
+function originOf(url) {
+  try {
+    return new URL(url).origin
+  } catch {
+    return null
+  }
+}
+
+/**
+ * CSRF guard for state-changing endpoints. Verifies Origin (or Referer) when
+ * present; a request with neither (non-browser/local tooling on loopback) is
+ * allowed. A browser always attaches Origin to cross-origin writes, so a
+ * foreign page is always rejected.
+ * @param {{ origin?: string, referer?: string }} headers
+ * @param {string[]} allowedOrigins
+ * @returns {{ allowed: boolean, reason: string }}
+ */
+export function isStateChangingRequestAllowed(headers = {}, allowedOrigins) {
+  const origin = headers.origin
+  if (typeof origin === 'string' && origin !== '') {
+    return isOriginAllowed(origin, allowedOrigins)
+      ? { allowed: true, reason: 'origin allowed' }
+      : { allowed: false, reason: `origin not allowed: ${origin}` }
+  }
+
+  const referer = headers.referer
+  if (typeof referer === 'string' && referer !== '') {
+    const refOrigin = originOf(referer)
+    return isOriginAllowed(refOrigin, allowedOrigins)
+      ? { allowed: true, reason: 'referer allowed' }
+      : { allowed: false, reason: `referer not allowed: ${referer}` }
+  }
+
+  return { allowed: true, reason: 'no origin/referer (non-browser)' }
+}
+
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Validate a ProfileChatter config payload (used by /generate-preview and
+ * /api/save-local-config) before any side effect.
+ * @param {unknown} body
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateConfigPayload(body) {
+  if (!isPlainObject(body)) {
+    return { valid: false, error: 'Body must be a JSON object' }
+  }
+  if (!body.profile || !body.activeTheme || !Array.isArray(body.chatMessages)) {
+    return {
+      valid: false,
+      error: 'Config must include profile, activeTheme, and a chatMessages array',
+    }
+  }
+  return { valid: true }
+}
+
+const REPO_FULL_NAME = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/
+const SAFE_BRANCH = /^[A-Za-z0-9._/-]+$/
+
+/**
+ * Allow-list for GitHub write targets. Constrains writes to a JSON config file
+ * (not under .github/) in a well-formed owner/repo on a sane branch — blocking
+ * path traversal, absolute paths, and CI-workflow injection.
+ * @param {{ repoFullName?: string, filePath?: string, branch?: string }} target
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateGithubSaveTarget(target = {}) {
+  const { repoFullName, filePath, branch = 'main' } = target
+
+  if (typeof repoFullName !== 'string' || !REPO_FULL_NAME.test(repoFullName)) {
+    return { valid: false, error: 'repoFullName must be of the form "owner/repo"' }
+  }
+
+  if (typeof branch !== 'string' || branch.includes('..') || !SAFE_BRANCH.test(branch)) {
+    return { valid: false, error: 'Invalid branch ref' }
+  }
+
+  if (typeof filePath !== 'string' || filePath === '') {
+    return { valid: false, error: 'filePath is required' }
+  }
+  if (
+    filePath.includes('..') ||
+    filePath.includes('\\') ||
+    filePath.includes('\0') ||
+    filePath.startsWith('/') ||
+    /^[A-Za-z]:/.test(filePath)
+  ) {
+    return { valid: false, error: 'filePath must be a safe relative path' }
+  }
+  const segments = filePath.split('/')
+  if (segments.includes('.github')) {
+    return { valid: false, error: 'Writes under .github/ are not allowed' }
+  }
+  if (!filePath.toLowerCase().endsWith('.json')) {
+    return { valid: false, error: 'Only .json config files may be written' }
+  }
+
+  return { valid: true }
+}

--- a/configurator-ui/server/serverSecurity.test.js
+++ b/configurator-ui/server/serverSecurity.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getAllowedOrigins,
+  isOriginAllowed,
+  resolveCorsOrigin,
+  isStateChangingRequestAllowed,
+  validateConfigPayload,
+  validateGithubSaveTarget,
+} from './serverSecurity.js'
+
+describe('getAllowedOrigins', () => {
+  it('defaults to the loopback configurator origins', () => {
+    const origins = getAllowedOrigins({})
+    expect(origins).toContain('http://127.0.0.1:5173')
+    expect(origins).toContain('http://localhost:5173')
+  })
+
+  it('accepts a comma-separated override via env', () => {
+    expect(getAllowedOrigins({ PREVIEW_ALLOWED_ORIGINS: 'http://localhost:4321' })).toEqual([
+      'http://localhost:4321',
+    ])
+  })
+})
+
+describe('isOriginAllowed', () => {
+  const allowed = ['http://127.0.0.1:5173']
+  it('accepts an exact allowed origin', () => {
+    expect(isOriginAllowed('http://127.0.0.1:5173', allowed)).toBe(true)
+  })
+  it('rejects a foreign origin', () => {
+    expect(isOriginAllowed('http://evil.example', allowed)).toBe(false)
+  })
+})
+
+describe('resolveCorsOrigin echoes only allowed origins (never *)', () => {
+  const allowed = ['http://127.0.0.1:5173']
+  it('echoes the request origin when allowed', () => {
+    expect(resolveCorsOrigin('http://127.0.0.1:5173', allowed)).toBe('http://127.0.0.1:5173')
+  })
+  it('falls back to the primary allowed origin for foreign or absent origins', () => {
+    expect(resolveCorsOrigin('http://evil.example', allowed)).toBe('http://127.0.0.1:5173')
+    expect(resolveCorsOrigin(undefined, allowed)).toBe('http://127.0.0.1:5173')
+  })
+})
+
+describe('isStateChangingRequestAllowed (CSRF guard)', () => {
+  const allowed = ['http://127.0.0.1:5173']
+  it('allows requests from the configurator origin', () => {
+    expect(
+      isStateChangingRequestAllowed({ origin: 'http://127.0.0.1:5173' }, allowed).allowed
+    ).toBe(true)
+  })
+  it('blocks a foreign Origin', () => {
+    expect(isStateChangingRequestAllowed({ origin: 'http://evil.example' }, allowed).allowed).toBe(
+      false
+    )
+  })
+  it('blocks a foreign Referer when no Origin is present', () => {
+    expect(
+      isStateChangingRequestAllowed({ referer: 'http://evil.example/page' }, allowed).allowed
+    ).toBe(false)
+  })
+  it('allows a non-browser request with neither Origin nor Referer (loopback tooling)', () => {
+    expect(isStateChangingRequestAllowed({}, allowed).allowed).toBe(true)
+  })
+})
+
+describe('validateConfigPayload', () => {
+  const good = { profile: {}, activeTheme: 'dark', chatMessages: [] }
+  it('accepts a well-formed config', () => {
+    expect(validateConfigPayload(good).valid).toBe(true)
+  })
+  it('rejects non-objects', () => {
+    expect(validateConfigPayload(null).valid).toBe(false)
+    expect(validateConfigPayload('x').valid).toBe(false)
+    expect(validateConfigPayload([]).valid).toBe(false)
+  })
+  it('rejects missing required fields', () => {
+    expect(validateConfigPayload({ profile: {}, activeTheme: 'dark' }).valid).toBe(false)
+    expect(validateConfigPayload({ activeTheme: 'dark', chatMessages: [] }).valid).toBe(false)
+    expect(validateConfigPayload({ profile: {}, chatMessages: [] }).valid).toBe(false)
+  })
+})
+
+describe('validateGithubSaveTarget (repo/path allow-list)', () => {
+  const ok = {
+    repoFullName: 'dsj7419/ProfileChatter',
+    filePath: 'profileChatterConfig.json',
+    branch: 'main',
+  }
+  it('accepts the default config save target', () => {
+    expect(validateGithubSaveTarget(ok).valid).toBe(true)
+  })
+  it('rejects path traversal', () => {
+    expect(validateGithubSaveTarget({ ...ok, filePath: '../../etc/passwd.json' }).valid).toBe(false)
+  })
+  it('rejects absolute paths and backslashes', () => {
+    expect(validateGithubSaveTarget({ ...ok, filePath: '/etc/x.json' }).valid).toBe(false)
+    expect(validateGithubSaveTarget({ ...ok, filePath: 'a\\b.json' }).valid).toBe(false)
+  })
+  it('rejects non-json files (blocks workflow injection)', () => {
+    expect(validateGithubSaveTarget({ ...ok, filePath: '.github/workflows/evil.yml' }).valid).toBe(
+      false
+    )
+  })
+  it('rejects writes anywhere under .github/', () => {
+    expect(validateGithubSaveTarget({ ...ok, filePath: '.github/config.json' }).valid).toBe(false)
+  })
+  it('rejects a malformed repo name', () => {
+    expect(validateGithubSaveTarget({ ...ok, repoFullName: 'not-a-repo' }).valid).toBe(false)
+    expect(validateGithubSaveTarget({ ...ok, repoFullName: 'a/b/c' }).valid).toBe(false)
+  })
+  it('rejects a dangerous branch ref', () => {
+    expect(validateGithubSaveTarget({ ...ok, branch: '../evil' }).valid).toBe(false)
+  })
+  it('rejects missing required fields', () => {
+    expect(validateGithubSaveTarget({ repoFullName: 'a/b' }).valid).toBe(false)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:integration": "vitest run --dir tests/integration",
     "test:watch": "vitest watch",
     "coverage": "vitest run --coverage",
-    "repomix": "repomix --style plain --ignore profileChatterConfig.json"
+    "repomix": "npx --yes repomix"
   },
   "keywords": [
     "svg",

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -1,0 +1,54 @@
+{
+  "include": [
+    "src/**",
+    "configurator-ui/src/**",
+    "configurator-ui/server/**",
+    "configurator-ui/index.html",
+    "configurator-ui/package.json",
+    "configurator-ui/vite.config.js",
+    "configurator-ui/svelte.config.js",
+    "configurator-ui/tailwind.config.js",
+    "configurator-ui/postcss.config.js",
+    "tests/**",
+    ".github/workflows/**",
+    "data/**",
+    "package.json",
+    "vitest.config.js",
+    ".eslintrc.json",
+    ".prettierrc.json",
+    ".gitattributes",
+    ".env.template",
+    "test.html",
+    "README.md",
+    "CONTRIBUTING.md",
+    "CHANGELOG.md",
+    "MANUAL_QA_TEST_PLAN.md",
+    "LICENSE"
+  ],
+  "ignore": {
+    "useGitignore": true,
+    "useDefaultPatterns": true,
+    "customPatterns": [
+      "profileChatterConfig.json",
+      "package-lock.json",
+      "configurator-ui/package-lock.json",
+      "tests/coverage/**",
+      "FORENSICS_REPORT.md",
+      ".forensics/**",
+      "repomix*.txt",
+      "repomix*.md",
+      "**/*.svg",
+      "**/*.png"
+    ]
+  },
+  "output": {
+    "filePath": "profilechatter-full-export.md",
+    "style": "markdown",
+    "fileSummary": true,
+    "directoryStructure": true,
+    "removeComments": false,
+    "removeEmptyLines": false,
+    "compress": false,
+    "showLineNumbers": true
+  }
+}


### PR DESCRIPTION
## Security fix (P0 — preview server hardening, part 2 / server-side)

> **Stacked on #13 (PR-1a).** Merge #12 → #13 → this. Server-side only; the existing local configurator flow is unchanged.

Closes the realistic browser-based CSRF / cross-origin threat for the loopback-default posture established in PR-1a, validates request bodies before side effects, and constrains GitHub writes. The session **token + SPA wiring** (for the opt-in external-bind case) is the agreed follow-up, **PR-1c**.

### Changes
- **Strict CORS** — dropped wildcard `*`; echo only the configurator origin (`http://127.0.0.1:5173` / `http://localhost:5173`, overridable via `PREVIEW_ALLOWED_ORIGINS`) + `Vary: Origin`.
- **CSRF guard** — state-changing endpoints (the 3 POSTs + the token-backed `GET /api/github/user-repos`) reject a foreign `Origin`/`Referer`. Loopback non-browser tooling (no Origin) still works.
- **Payload validation before side effects** — `POST /api/save-local-config` now validates the config (`profile` + `activeTheme` + `chatMessages[]`) **before** writing to disk (previously wrote the raw body).
- **GitHub write allow-list** — `repoFullName` must be `owner/repo`, `branch` a safe ref, `filePath` a relative **`.json`** file **not under `.github/`** — blocking path traversal, absolute paths, and CI-workflow injection.
- New **`serverSecurity.js`** (pure) + **`serverSecurity.test.js`** (21 tests).

### Acceptance
- [x] Foreign-Origin requests cannot trigger state-changing endpoints.
- [x] The allowed local configurator origin still works.
- [x] Missing/invalid POST bodies are rejected before side effects.
- [x] GitHub writes are constrained to approved repo/path targets.
- [x] Tests cover allowed and rejected cases.
- [x] Existing local configurator flow remains intact (server-side only).
- [x] No frontend cleanup / reliability work included.

### Test proof
`vitest run`: **458/458 pass** (32 files; +21). `eslint .` clean. `node --check` OK.

### Manual verification (booted server)
| Check | Result |
|---|---|
| foreign-origin `POST /generate-preview` | **403** |
| loopback curl `POST /api/save-local-config` (bad body) | **400** (guard allows loopback; validation rejects before write) |
| allowed-origin `POST /api/save-local-config` (bad body) | **400** (validation) |
| allowed-origin `POST /api/github/save-config` → `.github/workflows/evil.yml` | **400** (allow-list) |
| CORS `Access-Control-Allow-Origin` for a foreign origin | `http://127.0.0.1:5173` (not `*`, not attacker) |

### Follow-up (PR-1c)
Per-process session token + `/preview-token` distribution + SPA fetch wiring, to also defend the opt-in external-bind mode.
