### PR TITLE
feat(preview-server): session-token auth for state-changing endpoints (P0, PR-1c)

### DIFF
--- a/configurator-ui/server/previewServer.js
+++ b/configurator-ui/server/previewServer.js
@@ -31,16 +31,19 @@ import { resolveBindHost, isExternalBind, isDebugEndpointEnabled } from './serve
 import {
   getAllowedOrigins,
   resolveCorsOrigin,
-  isStateChangingRequestAllowed,
+  authorizeStateChange,
   validateConfigPayload,
   validateGithubSaveTarget,
 } from './serverSecurity.js'
+import { generateSessionToken, isLoopbackHost } from './serverAuth.js'
 
 // Constants
 const PORT = 3001
 // Default to loopback; LAN exposure is opt-in only (see serverConfig.js).
 const HOST = resolveBindHost(process.env)
 const ALLOWED_ORIGINS = getAllowedOrigins(process.env)
+// Per-process session token; handed to the SPA via loopback-only GET /preview-token
+const PREVIEW_TOKEN = generateSessionToken()
 const FRONTEND_URL = 'http://127.0.0.1:5173'
 const FIVE_MINUTES_SEC = 5 * 60
 const FIVE_MINUTES_MS = FIVE_MINUTES_SEC * 1000
@@ -821,7 +824,7 @@ const server = http.createServer(async (req, res) => {
     )
     res.setHeader('Vary', 'Origin')
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Preview-Token')
 
     // Handle preflight request
     if (req.method === 'OPTIONS') {
@@ -831,16 +834,20 @@ const server = http.createServer(async (req, res) => {
       return
     }
 
-    // CSRF guard: reject cross-origin attempts at state-changing / token-backed endpoints
+    // Auth guard: state-changing / token-backed endpoints require an allowed
+    // origin (CSRF) AND a valid session token.
     const isStateChanging =
       req.method === 'POST' || (req.method === 'GET' && path === '/api/github/user-repos')
     if (isStateChanging) {
-      const originCheck = isStateChangingRequestAllowed(req.headers, ALLOWED_ORIGINS)
-      if (!originCheck.allowed) {
-        logger.warn('Blocked cross-origin request:', originCheck.reason, path)
-        res.statusCode = 403
+      const auth = authorizeStateChange(req.headers, {
+        expectedToken: PREVIEW_TOKEN,
+        allowedOrigins: ALLOWED_ORIGINS,
+      })
+      if (!auth.allowed) {
+        logger.warn('Blocked state-changing request:', auth.status, auth.error, path)
+        res.statusCode = auth.status
         res.setHeader('Content-Type', 'application/json')
-        res.end(JSON.stringify({ error: 'Forbidden: cross-origin request rejected' }))
+        res.end(JSON.stringify({ error: auth.error }))
         return
       }
     }
@@ -855,6 +862,21 @@ const server = http.createServer(async (req, res) => {
         await routes.handleOAuthCallback(req, res, query, path)
       } else if (path === '/oauth-status') {
         await routes.handleOAuthStatus(req, res)
+      } else if (path === '/preview-token') {
+        // Hand the per-process token to the local SPA. Loopback-Host only, so a
+        // LAN caller on the opt-in external-bind path cannot obtain it; CORS
+        // already restricts which browser origin may read the response.
+        if (!isLoopbackHost(req.headers.host)) {
+          logger.warn('Blocked /preview-token from non-loopback host:', req.headers.host)
+          res.statusCode = 403
+          res.setHeader('Content-Type', 'application/json')
+          res.end(JSON.stringify({ error: 'Forbidden' }))
+        } else {
+          res.statusCode = 200
+          res.setHeader('Content-Type', 'application/json')
+          res.setHeader('Cache-Control', 'no-store')
+          res.end(JSON.stringify({ token: PREVIEW_TOKEN }))
+        }
       } else if (path === '/api/initial-config-data') {
         await routes.handleConfigData(req, res)
       } else if (path === '/api/github/user-repos') {

--- a/configurator-ui/server/serverAuth.js
+++ b/configurator-ui/server/serverAuth.js
@@ -1,0 +1,60 @@
+/**
+ * serverAuth.js
+ *
+ * Per-process session-token primitives for the preview server. The token gates
+ * state-changing endpoints; it is handed to the local configurator SPA via a
+ * loopback-only /preview-token endpoint (see previewServer.js) so that, even on
+ * the opt-in external-bind path, a LAN caller cannot obtain or forge it.
+ *
+ * Pure/deterministic helpers are unit-tested; token generation uses the CSPRNG.
+ */
+
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost'])
+
+/**
+ * Mint a fresh, unguessable session token (CSPRNG, 32 bytes → 64 hex chars).
+ * @returns {string}
+ */
+export function generateSessionToken() {
+  return randomBytes(32).toString('hex')
+}
+
+/**
+ * Whether an HTTP `Host` header refers to a loopback interface. Used to gate
+ * /preview-token: the SPA reaches the server via 127.0.0.1, a LAN attacker via
+ * the machine's routable IP (rejected).
+ * @param {string | undefined | null} hostHeader - e.g. "127.0.0.1:3001"
+ * @returns {boolean}
+ */
+export function isLoopbackHost(hostHeader) {
+  if (typeof hostHeader !== 'string' || hostHeader === '') {
+    return false
+  }
+  try {
+    let { hostname } = new URL(`http://${hostHeader}`)
+    if (hostname.startsWith('[') && hostname.endsWith(']')) {
+      hostname = hostname.slice(1, -1) // unwrap IPv6 literal, e.g. [::1] -> ::1
+    }
+    return LOOPBACK_HOSTS.has(hostname)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Constant-time comparison of a provided token against the expected one.
+ * @param {string | undefined | null} provided
+ * @param {string | undefined | null} expected
+ * @returns {boolean}
+ */
+export function isValidPreviewToken(provided, expected) {
+  if (typeof provided !== 'string' || provided === '') return false
+  if (typeof expected !== 'string' || expected === '') return false
+
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length) return false
+  return timingSafeEqual(a, b)
+}

--- a/configurator-ui/server/serverAuth.test.js
+++ b/configurator-ui/server/serverAuth.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { generateSessionToken, isLoopbackHost, isValidPreviewToken } from './serverAuth.js'
+
+describe('generateSessionToken', () => {
+  it('returns a 64-char hex token', () => {
+    expect(generateSessionToken()).toMatch(/^[0-9a-f]{64}$/)
+  })
+  it('returns a different token each call', () => {
+    expect(generateSessionToken()).not.toBe(generateSessionToken())
+  })
+})
+
+describe('isLoopbackHost (gate for /preview-token)', () => {
+  it('accepts loopback hosts with a port', () => {
+    expect(isLoopbackHost('127.0.0.1:3001')).toBe(true)
+    expect(isLoopbackHost('localhost:5173')).toBe(true)
+    expect(isLoopbackHost('[::1]:3001')).toBe(true)
+  })
+  it('accepts loopback hosts without a port', () => {
+    expect(isLoopbackHost('127.0.0.1')).toBe(true)
+    expect(isLoopbackHost('localhost')).toBe(true)
+  })
+  it('rejects LAN IPs and external hosts', () => {
+    expect(isLoopbackHost('192.168.1.50:3001')).toBe(false)
+    expect(isLoopbackHost('evil.example')).toBe(false)
+    expect(isLoopbackHost('10.0.0.5:3001')).toBe(false)
+  })
+  it('rejects a missing/empty Host header', () => {
+    expect(isLoopbackHost(undefined)).toBe(false)
+    expect(isLoopbackHost('')).toBe(false)
+  })
+})
+
+describe('isValidPreviewToken', () => {
+  const token = 'a'.repeat(64)
+  it('accepts a matching token', () => {
+    expect(isValidPreviewToken(token, token)).toBe(true)
+  })
+  it('rejects a mismatched token', () => {
+    expect(isValidPreviewToken('b'.repeat(64), token)).toBe(false)
+  })
+  it('rejects missing/empty provided token', () => {
+    expect(isValidPreviewToken(undefined, token)).toBe(false)
+    expect(isValidPreviewToken('', token)).toBe(false)
+  })
+  it('rejects when no expected token is configured', () => {
+    expect(isValidPreviewToken(token, '')).toBe(false)
+    expect(isValidPreviewToken(token, undefined)).toBe(false)
+  })
+})

--- a/configurator-ui/server/serverSecurity.js
+++ b/configurator-ui/server/serverSecurity.js
@@ -9,6 +9,8 @@
  * unit-tested without an HTTP server.
  */
 
+import { isValidPreviewToken } from './serverAuth.js'
+
 const DEFAULT_ALLOWED_ORIGINS = ['http://127.0.0.1:5173', 'http://localhost:5173']
 
 /**
@@ -150,4 +152,22 @@ export function validateGithubSaveTarget(target = {}) {
   }
 
   return { valid: true }
+}
+
+/**
+ * Authorize a state-changing request: cross-origin check first (403), then a
+ * valid session token (401). Both must pass.
+ * @param {Record<string, string | undefined>} headers
+ * @param {{ expectedToken: string, allowedOrigins: string[] }} ctx
+ * @returns {{ allowed: boolean, status: number, error?: string }}
+ */
+export function authorizeStateChange(headers = {}, { expectedToken, allowedOrigins }) {
+  const origin = isStateChangingRequestAllowed(headers, allowedOrigins)
+  if (!origin.allowed) {
+    return { allowed: false, status: 403, error: 'Forbidden: cross-origin request rejected' }
+  }
+  if (!isValidPreviewToken(headers['x-preview-token'], expectedToken)) {
+    return { allowed: false, status: 401, error: 'Unauthorized: missing or invalid preview token' }
+  }
+  return { allowed: true, status: 200 }
 }

--- a/configurator-ui/server/serverSecurity.test.js
+++ b/configurator-ui/server/serverSecurity.test.js
@@ -6,6 +6,7 @@ import {
   isStateChangingRequestAllowed,
   validateConfigPayload,
   validateGithubSaveTarget,
+  authorizeStateChange,
 } from './serverSecurity.js'
 
 describe('getAllowedOrigins', () => {
@@ -115,5 +116,47 @@ describe('validateGithubSaveTarget (repo/path allow-list)', () => {
   })
   it('rejects missing required fields', () => {
     expect(validateGithubSaveTarget({ repoFullName: 'a/b' }).valid).toBe(false)
+  })
+})
+
+describe('authorizeStateChange (origin + token)', () => {
+  const allowedOrigins = ['http://127.0.0.1:5173']
+  const expectedToken = 'a'.repeat(64)
+  const ctx = { expectedToken, allowedOrigins }
+
+  it('allows an allowed origin with a valid token', () => {
+    const r = authorizeStateChange(
+      { origin: 'http://127.0.0.1:5173', 'x-preview-token': expectedToken },
+      ctx
+    )
+    expect(r.allowed).toBe(true)
+  })
+
+  it('allows a no-origin (loopback tooling) request with a valid token', () => {
+    expect(authorizeStateChange({ 'x-preview-token': expectedToken }, ctx).allowed).toBe(true)
+  })
+
+  it('rejects a foreign origin with 403 before checking the token', () => {
+    const r = authorizeStateChange(
+      { origin: 'http://evil.example', 'x-preview-token': expectedToken },
+      ctx
+    )
+    expect(r.allowed).toBe(false)
+    expect(r.status).toBe(403)
+  })
+
+  it('rejects a missing token with 401', () => {
+    const r = authorizeStateChange({ origin: 'http://127.0.0.1:5173' }, ctx)
+    expect(r.allowed).toBe(false)
+    expect(r.status).toBe(401)
+  })
+
+  it('rejects an invalid token with 401', () => {
+    const r = authorizeStateChange(
+      { origin: 'http://127.0.0.1:5173', 'x-preview-token': 'b'.repeat(64) },
+      ctx
+    )
+    expect(r.allowed).toBe(false)
+    expect(r.status).toBe(401)
   })
 })

--- a/configurator-ui/src/components/GitHubSaveUIManager.svelte
+++ b/configurator-ui/src/components/GitHubSaveUIManager.svelte
@@ -2,6 +2,7 @@
 <script>
     import { getPreviewConfiguration } from '../stores/configStore.js'
     import HelpIconTooltip from '../lib/ui/HelpIconTooltip.svelte'
+    import { getPreviewToken } from '../lib/previewToken.js'
   
     // Props for GitHub authentication status
     export let isAuthenticated = false
@@ -30,7 +31,10 @@
         isLoadingRepos = true
         repoError = null
         
-        const res = await fetch(`${previewServer}/api/github/user-repos`)
+        const token = await getPreviewToken(previewServer)
+        const res = await fetch(`${previewServer}/api/github/user-repos`, {
+          headers: { 'X-Preview-Token': token },
+        })
         
         if (!res.ok) {
           const data = await res.json().catch(() => ({}))
@@ -76,9 +80,10 @@
         // Get the current configuration from the store
         const configContent = JSON.stringify(getPreviewConfiguration(), null, 2)
         
+        const token = await getPreviewToken(previewServer)
         const res = await fetch(`${previewServer}/api/github/save-config`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', 'X-Preview-Token': token },
           body: JSON.stringify({
             repoFullName: selectedRepoFullName,
             filePath,

--- a/configurator-ui/src/components/ServerTest.svelte
+++ b/configurator-ui/src/components/ServerTest.svelte
@@ -2,6 +2,7 @@
 
 <script>
   import { onMount } from 'svelte';
+  import { getPreviewToken } from '../lib/previewToken.js';
   
   let testResult = '';
   let isLoading = false;
@@ -55,9 +56,10 @@
         ]
       };
       
+      const token = await getPreviewToken(previewServer);
       const response = await fetch(`${previewServer}/generate-preview`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'X-Preview-Token': token },
         body: JSON.stringify(simplePayload)
       });
       

--- a/configurator-ui/src/components/SvgPreviewRenderer.svelte
+++ b/configurator-ui/src/components/SvgPreviewRenderer.svelte
@@ -6,8 +6,9 @@
       chatMessages, 
       editableTheme,
       getPreviewConfiguration,
-      previewMode 
+      previewMode
     } from '../stores/configStore.js';
+    import { getPreviewToken } from '../lib/previewToken.js';
     
     // State for SVG preview
     let generatedSvgMarkup = '';
@@ -216,10 +217,12 @@
         });
         
         // Send POST request to preview server
+        const token = await getPreviewToken(previewServer);
         const response = await fetch(`${previewServer}/generate-preview`, {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'X-Preview-Token': token
           },
           body: JSON.stringify(fullConfigData)
         });

--- a/configurator-ui/src/lib/previewToken.js
+++ b/configurator-ui/src/lib/previewToken.js
@@ -1,0 +1,38 @@
+/**
+ * previewToken.js
+ *
+ * Fetches and caches the preview server's per-process session token so the
+ * configurator can attach it (as `X-Preview-Token`) to state-changing requests.
+ * The server only issues the token to loopback callers, so it never leaves the
+ * developer's machine.
+ */
+
+/** @type {Map<string, Promise<string>>} */
+const tokenCache = new Map()
+
+/**
+ * Get the preview-server session token (cached per server URL). Resolves to ''
+ * if the token can't be obtained; a failed attempt is not cached, so a later
+ * call retries.
+ * @param {string} previewServer - e.g. "http://localhost:3001"
+ * @returns {Promise<string>}
+ */
+export function getPreviewToken(previewServer) {
+  if (!tokenCache.has(previewServer)) {
+    const pending = fetch(`${previewServer}/preview-token`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => (data && data.token ? data.token : ''))
+      .catch(() => '')
+      .then((token) => {
+        if (!token) tokenCache.delete(previewServer)
+        return token
+      })
+    tokenCache.set(previewServer, pending)
+  }
+  return tokenCache.get(previewServer)
+}
+
+/** Test-only: clear the cached tokens. */
+export function __resetPreviewTokenCache() {
+  tokenCache.clear()
+}

--- a/configurator-ui/src/lib/previewToken.test.js
+++ b/configurator-ui/src/lib/previewToken.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getPreviewToken, __resetPreviewTokenCache } from './previewToken.js'
+
+beforeEach(() => {
+  __resetPreviewTokenCache()
+})
+
+describe('getPreviewToken', () => {
+  it('fetches the token from the preview server /preview-token endpoint', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ token: 'tok123' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const token = await getPreviewToken('http://localhost:3001')
+
+    expect(token).toBe('tok123')
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:3001/preview-token')
+  })
+
+  it('caches the token so repeated calls make a single request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ token: 'tok' }) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getPreviewToken('http://localhost:3001')
+    await getPreviewToken('http://localhost:3001')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns empty string on failure without poisoning the cache (retries next time)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+    expect(await getPreviewToken('http://localhost:3001')).toBe('')
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ token: 'later' }) })
+    )
+    expect(await getPreviewToken('http://localhost:3001')).toBe('later')
+  })
+})

--- a/configurator-ui/src/stores/configStore.js
+++ b/configurator-ui/src/stores/configStore.js
@@ -1,5 +1,6 @@
 import { writable } from 'svelte/store'
 import { applyConfig } from './initConfigLoader.js'
+import { getPreviewToken } from '../lib/previewToken.js'
 
 // Initial default values
 const defaultThemes = {
@@ -531,9 +532,10 @@ async function saveLocalConfigToServer() {
     const fullConfig = getPreviewConfiguration()
     console.log('Saving configuration to local file system...')
 
+    const token = await getPreviewToken('http://localhost:3001')
     const response = await fetch('http://localhost:3001/api/save-local-config', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'X-Preview-Token': token },
       body: JSON.stringify(fullConfig),
     })
 

--- a/configurator-ui/src/stores/configStore.js
+++ b/configurator-ui/src/stores/configStore.js
@@ -1,5 +1,5 @@
-import { writable } from 'svelte/store';
-import { applyConfig } from './initConfigLoader.js';
+import { writable } from 'svelte/store'
+import { applyConfig } from './initConfigLoader.js'
 
 // Initial default values
 const defaultThemes = {
@@ -11,8 +11,9 @@ const defaultThemes = {
     BACKGROUND_LIGHT: '#FFFFFF',
     BACKGROUND_DARK: '#000000',
     BUBBLE_RADIUS_PX: 18,
-    FONT_FAMILY: "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
-    
+    FONT_FAMILY:
+      "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+
     REACTION_FONT_SIZE_PX: 20,
     REACTION_BG_COLOR: '#F1F1F1',
     REACTION_BG_OPACITY: 0.9,
@@ -24,7 +25,7 @@ const defaultThemes = {
     REACTION_OFFSET_Y_PX: -12,
     REACTION_ANIMATION_DURATION_SEC: 0.3,
     REACTION_ANIMATION_DELAY_SEC: 0.2,
-    
+
     CHART_STYLES: {
       BAR_DEFAULT_COLOR: '#007AFF',
       BAR_TRACK_COLOR: '#D3D3D8',
@@ -32,11 +33,14 @@ const defaultThemes = {
       VALUE_TEXT_INSIDE_COLOR: '#FFFFFF',
       BAR_HEIGHT_PX: 18,
       BAR_SPACING_PX: 10,
-      LABEL_FONT_FAMILY: "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+      LABEL_FONT_FAMILY:
+        "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
       LABEL_FONT_SIZE_PX: 13,
-      VALUE_TEXT_FONT_FAMILY: "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+      VALUE_TEXT_FONT_FAMILY:
+        "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
       VALUE_TEXT_FONT_SIZE_PX: 12,
-      TITLE_FONT_FAMILY: "'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+      TITLE_FONT_FAMILY:
+        "'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
       TITLE_FONT_SIZE_PX: 15,
       TITLE_LINE_HEIGHT_MULTIPLIER: 1.3,
       TITLE_BOTTOM_MARGIN_PX: 10,
@@ -46,7 +50,8 @@ const defaultThemes = {
       GRID_LINE_COLOR: '#F5F5F5',
       DONUT_STROKE_WIDTH_PX: 30,
       DONUT_CENTER_TEXT_FONT_SIZE_PX: 16,
-      DONUT_CENTER_TEXT_FONT_FAMILY: "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+      DONUT_CENTER_TEXT_FONT_FAMILY:
+        "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
       ME_DONUT_CENTER_TEXT_COLOR: '#FFFFFF',
       VISITOR_DONUT_CENTER_TEXT_COLOR: '#000000',
       ME_DONUT_LEGEND_TEXT_COLOR: '#FFFFFF',
@@ -59,15 +64,15 @@ const defaultThemes = {
       CHART_BAR_ANIMATION_DURATION_SEC: 0.8,
       CHART_ANIMATION_DELAY_SEC: 0.3,
       BAR_ANIMATION_DURATION_SEC: 0.8,
-    
+
       ME_TITLE_COLOR: '#FFFFFF',
       ME_LABEL_COLOR: '#E2F0FF',
       ME_VALUE_TEXT_COLOR: '#FFFFFF',
-    
+
       VISITOR_TITLE_COLOR: '#000000',
       VISITOR_LABEL_COLOR: '#444444',
       VISITOR_VALUE_TEXT_COLOR: '#000000',
-    }
+    },
   },
   android: {
     ME_BUBBLE_COLOR: '#D1E6FF',
@@ -78,7 +83,7 @@ const defaultThemes = {
     BACKGROUND_DARK: '#121212',
     BUBBLE_RADIUS_PX: 8,
     FONT_FAMILY: "'Roboto', sans-serif",
-    
+
     REACTION_FONT_SIZE_PX: 14,
     REACTION_BG_COLOR: '#E8E8E8',
     REACTION_BG_OPACITY: 1.0,
@@ -90,7 +95,7 @@ const defaultThemes = {
     REACTION_OFFSET_Y_PX: -10,
     REACTION_ANIMATION_DURATION_SEC: 0.3,
     REACTION_ANIMATION_DELAY_SEC: 0.2,
-    
+
     CHART_STYLES: {
       BAR_DEFAULT_COLOR: '#4285F4',
       BAR_TRACK_COLOR: '#CCCCCC',
@@ -133,7 +138,7 @@ const defaultThemes = {
       VISITOR_TITLE_COLOR: '#212121',
       VISITOR_LABEL_COLOR: '#616161',
       VISITOR_VALUE_TEXT_COLOR: '#212121',
-    }
+    },
   },
   discord: {
     ME_BUBBLE_COLOR: '#5865F2',
@@ -144,7 +149,7 @@ const defaultThemes = {
     BACKGROUND_DARK: '#36393F',
     BUBBLE_RADIUS_PX: 8,
     FONT_FAMILY: "'gg sans', 'Whitney', 'Helvetica Neue', Helvetica, Arial, sans-serif",
-    
+
     REACTION_FONT_SIZE_PX: 16,
     REACTION_BG_COLOR: '#40444B',
     REACTION_BG_OPACITY: 0.9,
@@ -156,7 +161,7 @@ const defaultThemes = {
     REACTION_OFFSET_Y_PX: -12,
     REACTION_ANIMATION_DURATION_SEC: 0.3,
     REACTION_ANIMATION_DELAY_SEC: 0.2,
-    
+
     CHART_STYLES: {
       BAR_DEFAULT_COLOR: '#5865F2',
       BAR_TRACK_COLOR: '#4F545C',
@@ -166,7 +171,8 @@ const defaultThemes = {
       BAR_SPACING_PX: 10,
       LABEL_FONT_FAMILY: "'gg sans', 'Whitney', 'Helvetica Neue', Helvetica, Arial, sans-serif",
       LABEL_FONT_SIZE_PX: 13,
-      VALUE_TEXT_FONT_FAMILY: "'gg sans', 'Whitney', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+      VALUE_TEXT_FONT_FAMILY:
+        "'gg sans', 'Whitney', 'Helvetica Neue', Helvetica, Arial, sans-serif",
       VALUE_TEXT_FONT_SIZE_PX: 12,
       TITLE_FONT_FAMILY: "'gg sans', 'Whitney', 'Helvetica Neue', Helvetica, Arial, sans-serif",
       TITLE_FONT_SIZE_PX: 15,
@@ -178,7 +184,8 @@ const defaultThemes = {
       GRID_LINE_COLOR: '#2F3136',
       DONUT_STROKE_WIDTH_PX: 28,
       DONUT_CENTER_TEXT_FONT_SIZE_PX: 16,
-      DONUT_CENTER_TEXT_FONT_FAMILY: "'gg sans', 'Whitney', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+      DONUT_CENTER_TEXT_FONT_FAMILY:
+        "'gg sans', 'Whitney', 'Helvetica Neue', Helvetica, Arial, sans-serif",
       ME_DONUT_CENTER_TEXT_COLOR: '#FFFFFF',
       VISITOR_DONUT_CENTER_TEXT_COLOR: '#DCDDDE',
       ME_DONUT_LEGEND_TEXT_COLOR: '#FFFFFF',
@@ -191,17 +198,17 @@ const defaultThemes = {
       CHART_BAR_ANIMATION_DURATION_SEC: 0.8,
       CHART_ANIMATION_DELAY_SEC: 0.3,
       BAR_ANIMATION_DURATION_SEC: 0.8,
-    
+
       ME_TITLE_COLOR: '#FFFFFF',
       ME_LABEL_COLOR: '#B9BBBE',
       ME_VALUE_TEXT_COLOR: '#FFFFFF',
-    
+
       VISITOR_TITLE_COLOR: '#DCDDDE',
       VISITOR_LABEL_COLOR: '#B9BBBE',
       VISITOR_VALUE_TEXT_COLOR: '#DCDDDE',
-    }
-  }
-};
+    },
+  },
+}
 
 // Default font options
 const defaultFontOptions = {
@@ -213,38 +220,38 @@ const defaultFontOptions = {
     "'Helvetica Neue', Helvetica, Arial, sans-serif",
     "'Arial', sans-serif",
     "'Georgia', serif",
-    "'Courier New', monospace"
-  ]
-};
+    "'Courier New', monospace",
+  ],
+}
 
 // Initial profile configuration
 const initialProfileConfig = {
-  NAME: "Your Name",
-  PROFESSION: "Your Profession",
-  LOCATION: "Your City",
-  COMPANY: "Your Company",
-  CURRENT_PROJECT: "ProfileChatter SVG Generator",
-  GITHUB_USERNAME: "your_github",
-  WAKATIME_USERNAME: "your_wakatime",
-  TWITTER_USERNAME: "",
-  TWITTER_FOLLOWERS: "0",
-  CODESTATS_USERNAME: "",
-  TIMEZONE: "UTC" // Default timezone
-};
+  NAME: 'Your Name',
+  PROFESSION: 'Your Profession',
+  LOCATION: 'Your City',
+  COMPANY: 'Your Company',
+  CURRENT_PROJECT: 'ProfileChatter SVG Generator',
+  GITHUB_USERNAME: 'your_github',
+  WAKATIME_USERNAME: 'your_wakatime',
+  TWITTER_USERNAME: '',
+  TWITTER_FOLLOWERS: '0',
+  CODESTATS_USERNAME: '',
+  TIMEZONE: 'UTC', // Default timezone
+}
 
 // Initial avatar configuration
 const initialAvatarsConfig = {
   enabled: true,
-  me: { imageUrl: "", fallbackText: "ME" },
-  visitor: { imageUrl: "", fallbackText: "?" },
+  me: { imageUrl: '', fallbackText: 'ME' },
+  visitor: { imageUrl: '', fallbackText: '?' },
   sizePx: 32,
-  shape: "circle",
-};
+  shape: 'circle',
+}
 
 // Initial weather configuration
 const initialWeatherConfig = {
-  enabled: true
-};
+  enabled: true,
+}
 
 // Initial placeholder data
 const initialPlaceholderData = [
@@ -252,44 +259,44 @@ const initialPlaceholderData = [
   {
     id: 'name',
     value: '{name}',
-    label: 'User\'s Name',
+    label: "User's Name",
     description: 'Your full name as configured in the Profile Settings.',
-    category: 'Profile Info'
+    category: 'Profile Info',
   },
   {
     id: 'profession',
     value: '{profession}',
     label: 'Profession',
     description: 'Your professional title or occupation as set in Profile Settings.',
-    category: 'Profile Info'
+    category: 'Profile Info',
   },
   {
     id: 'location',
     value: '{location}',
     label: 'Location',
     description: 'Your geographical location as defined in Profile Settings.',
-    category: 'Profile Info'
+    category: 'Profile Info',
   },
   {
     id: 'company',
     value: '{company}',
     label: 'Company',
     description: 'Your current company or organization name from Profile Settings.',
-    category: 'Profile Info'
+    category: 'Profile Info',
   },
   {
     id: 'currentProject',
     value: '{currentProject}',
     label: 'Current Project',
     description: 'The name of your current project as set in Profile Settings.',
-    category: 'Profile Info'
+    category: 'Profile Info',
   },
   {
     id: 'workTenure',
     value: '{workTenure}',
     label: 'Work Tenure',
     description: 'Time period at current company, calculated from Work Start Date.',
-    category: 'Profile Info'
+    category: 'Profile Info',
   },
 
   // Date & Time category
@@ -298,84 +305,84 @@ const initialPlaceholderData = [
     value: '{currentDayOfWeek}',
     label: 'Current Day of Week',
     description: 'The current day of the week (e.g., Monday, Tuesday).',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'currentDate',
     value: '{currentDate}',
     label: 'Current Date',
     description: 'The current date in a readable format (e.g., January 1, 2025).',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'dayName',
     value: '{dayName}',
     label: 'Day Name',
     description: 'Full name of the current day (e.g., "Wednesday").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'dayNameShort',
     value: '{dayNameShort}',
     label: 'Day Name (Short)',
     description: 'Abbreviated name of the current day (e.g., "Wed").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'monthName',
     value: '{monthName}',
     label: 'Month Name',
     description: 'Full name of the current month (e.g., "May").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'monthNameShort',
     value: '{monthNameShort}',
     label: 'Month Name (Short)',
     description: 'Abbreviated name of the current month (e.g., "Dec").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'day',
     value: '{day}',
     label: 'Day of Month',
     description: 'Current day of the month (e.g., "21").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'year',
     value: '{year}',
     label: 'Year',
     description: 'Current year (e.g., "2025").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'time',
     value: '{time}',
     label: 'Time (12-hour)',
     description: 'Current time in 12-hour format (e.g., "4:58 AM").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'time24',
     value: '{time24}',
     label: 'Time (24-hour)',
     description: 'Current time in 24-hour format (e.g., "16:58").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'dateTime',
     value: '{dateTime}',
     label: 'Full Date & Time',
     description: 'Complete date and time (e.g., "May 21, 2025, 4:58 AM").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
   {
     id: 'timezoneAbbr',
     value: '{timezoneAbbr}',
     label: 'Timezone Abbreviation',
     description: 'The abbreviation for your selected timezone (e.g., "EDT", "PST").',
-    category: 'Date & Time'
+    category: 'Date & Time',
   },
 
   // Weather category
@@ -384,21 +391,21 @@ const initialPlaceholderData = [
     value: '{temperature}',
     label: 'Temperature',
     description: 'Current temperature at your location, fetched from AccuWeather API.',
-    category: 'Weather'
+    category: 'Weather',
   },
   {
     id: 'weatherDescription',
     value: '{weatherDescription}',
     label: 'Weather Description',
     description: 'Text description of current weather conditions at your location.',
-    category: 'Weather'
+    category: 'Weather',
   },
   {
     id: 'emoji',
     value: '{emoji}',
     label: 'Weather Emoji',
     description: 'An emoji representing the current weather conditions.',
-    category: 'Weather'
+    category: 'Weather',
   },
 
   // GitHub Stats category
@@ -407,14 +414,14 @@ const initialPlaceholderData = [
     value: '{githubPublicRepos}',
     label: 'GitHub Public Repos',
     description: 'Number of your public repositories on GitHub.',
-    category: 'GitHub Stats'
+    category: 'GitHub Stats',
   },
   {
     id: 'githubFollowers',
     value: '{githubFollowers}',
     label: 'GitHub Followers',
     description: 'Your current follower count on GitHub.',
-    category: 'GitHub Stats'
+    category: 'GitHub Stats',
   },
 
   // WakaTime category
@@ -423,21 +430,21 @@ const initialPlaceholderData = [
     value: '{wakatime_summary}',
     label: 'WakaTime Summary',
     description: 'A summary of your coding activity from WakaTime.',
-    category: 'WakaTime'
+    category: 'WakaTime',
   },
   {
     id: 'wakatime_top_language',
     value: '{wakatime_top_language}',
     label: 'WakaTime Top Language',
     description: 'Your most used programming language according to WakaTime.',
-    category: 'WakaTime'
+    category: 'WakaTime',
   },
   {
     id: 'wakatime_top_language_percent',
     value: '{wakatime_top_language_percent}',
     label: 'WakaTime Top Language Percentage',
     description: 'Percentage of time spent using your top language on WakaTime.',
-    category: 'WakaTime'
+    category: 'WakaTime',
   },
 
   // Twitter Stats category
@@ -446,7 +453,7 @@ const initialPlaceholderData = [
     value: '{twitterFollowers}',
     label: 'Twitter Followers',
     description: 'Your current follower count on Twitter/X.',
-    category: 'Twitter Stats'
+    category: 'Twitter Stats',
   },
 
   // Code::Stats category
@@ -455,46 +462,47 @@ const initialPlaceholderData = [
     value: '{codestatsXP}',
     label: 'Code::Stats XP',
     description: 'Your experience points accumulated on Code::Stats.',
-    category: 'Code::Stats'
+    category: 'Code::Stats',
   },
-  
+
   // Spotify category
   {
     id: 'spotifyTrack',
     value: '{spotifyTrack}',
     label: 'Spotify Track',
-    description: 'Currently playing or last played track on Spotify (e.g., "Song Title by Artist Name"). Requires Spotify connection.',
-    category: 'Spotify'
+    description:
+      'Currently playing or last played track on Spotify (e.g., "Song Title by Artist Name"). Requires Spotify connection.',
+    category: 'Spotify',
   },
   {
     id: 'githubTotalStars',
     value: '{githubTotalStars}',
     label: 'GitHub Total Stars',
     description: 'Total number of stars received across all your repositories.',
-    category: 'GitHub Stats (OAuth)'
+    category: 'GitHub Stats (OAuth)',
   },
   {
     id: 'githubCommitsLastYear',
     value: '{githubCommitsLastYear}',
     label: 'GitHub Commits (Last Year)',
     description: 'Approximate number of commits you made in the last year.',
-    category: 'GitHub Stats (OAuth)'
+    category: 'GitHub Stats (OAuth)',
   },
   {
     id: 'githubContributedRepos',
     value: '{githubContributedRepos}',
     label: 'GitHub Contributed Repos',
     description: 'Number of repositories you have contributed to.',
-    category: 'GitHub Stats (OAuth)'
+    category: 'GitHub Stats (OAuth)',
   },
   {
     id: 'githubPrimaryLanguage',
     value: '{githubPrimaryLanguage}',
     label: 'GitHub Primary Language',
     description: 'Your most used programming language based on repository count.',
-    category: 'GitHub Stats (OAuth)'
-  }
-];
+    category: 'GitHub Stats (OAuth)',
+  },
+]
 
 /**
  * Debounce utility function - limits how often a function can be called
@@ -503,15 +511,15 @@ const initialPlaceholderData = [
  * @returns {Function} - Debounced function
  */
 function debounce(func, wait = 2000) {
-  let timeout;
+  let timeout
   return function executedFunction(...args) {
     const later = () => {
-      clearTimeout(timeout);
-      func(...args);
-    };
-    clearTimeout(timeout);
-    timeout = setTimeout(later, wait);
-  };
+      clearTimeout(timeout)
+      func(...args)
+    }
+    clearTimeout(timeout)
+    timeout = setTimeout(later, wait)
+  }
 }
 
 /**
@@ -520,143 +528,147 @@ function debounce(func, wait = 2000) {
  */
 async function saveLocalConfigToServer() {
   try {
-    const fullConfig = getPreviewConfiguration();
-    console.log('Saving configuration to local file system...');
-    
+    const fullConfig = getPreviewConfiguration()
+    console.log('Saving configuration to local file system...')
+
     const response = await fetch('http://localhost:3001/api/save-local-config', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(fullConfig)
-    });
-    
+      body: JSON.stringify(fullConfig),
+    })
+
     if (!response.ok) {
-      const errorData = await response.json();
-      throw new Error(`Server responded with ${response.status}: ${errorData.error || 'Unknown error'}`);
+      const errorData = await response.json()
+      throw new Error(
+        `Server responded with ${response.status}: ${errorData.error || 'Unknown error'}`
+      )
     }
-    
-    const result = await response.json();
-    console.log('Configuration saved successfully:', result.message);
+
+    const result = await response.json()
+    console.log('Configuration saved successfully:', result.message)
   } catch (error) {
-    console.error('Failed to save local configuration:', error.message);
+    console.error('Failed to save local configuration:', error.message)
   }
 }
 
 // Create debounced version of the save function with 2-second delay
-const debouncedSaveLocalConfig = debounce(saveLocalConfigToServer, 2000);
+const debouncedSaveLocalConfig = debounce(saveLocalConfigToServer, 2000)
 
 // Function to load config from the server API (async)
 async function loadConfigFromServer() {
   try {
-    const response = await fetch('http://localhost:3001/api/initial-config-data');
+    const response = await fetch('http://localhost:3001/api/initial-config-data')
     if (!response.ok) {
-      throw new Error(`Server returned ${response.status}`);
+      throw new Error(`Server returned ${response.status}`)
     }
-    return await response.json();
+    return await response.json()
   } catch (error) {
-    console.error('Failed to load config from server:', error);
+    console.error('Failed to load config from server:', error)
     // Return null on error, we'll fall back to defaults
-    return null;
+    return null
   }
 }
 
 // Create stores with default values
 export const userConfig = writable({
   profile: structuredClone(initialProfileConfig),
-  activeTheme: "ios",
+  activeTheme: 'ios',
   avatars: structuredClone(initialAvatarsConfig),
   weather: structuredClone(initialWeatherConfig),
   twitter: { enabled_api_fetch: false },
-  layout: { 
-    ANIMATION: { 
-      SCROLL_SPEED_MULTIPLIER: 1.0 
-    } 
-  }
-});
+  layout: {
+    ANIMATION: {
+      SCROLL_SPEED_MULTIPLIER: 1.0,
+    },
+  },
+})
 
 // Source of themes with defaults
-export const themes = writable(structuredClone(defaultThemes));
+export const themes = writable(structuredClone(defaultThemes))
 
 // Source of font options
-export const fontOptions = writable(structuredClone(defaultFontOptions));
+export const fontOptions = writable(structuredClone(defaultFontOptions))
 
 // Create a store for the editable theme based on the active theme
-export const editableTheme = writable(structuredClone(defaultThemes.ios));
+export const editableTheme = writable(structuredClone(defaultThemes.ios))
 
 // Create a store for placeholder data
-export const placeholderData = writable(structuredClone(initialPlaceholderData));
+export const placeholderData = writable(structuredClone(initialPlaceholderData))
 
 // Create a store for the preview mode (light/dark)
-/** 
+/**
  * Single source-of-truth for light/dark preview state.
  * Values: 'light' | 'dark'
  */
-export const previewMode = writable('light');
+export const previewMode = writable('light')
 
 // When userConfig changes, update the editableTheme
-userConfig.subscribe(value => {
+userConfig.subscribe((value) => {
   if (value.activeTheme) {
-    themes.subscribe(allThemes => {
+    themes.subscribe((allThemes) => {
       if (allThemes[value.activeTheme]) {
-        editableTheme.set(structuredClone(allThemes[value.activeTheme]));
+        editableTheme.set(structuredClone(allThemes[value.activeTheme]))
       }
-    });
+    })
   }
-});
+})
 
 // Flag to track initial load status
-let initialLoadComplete = false;
+let initialLoadComplete = false
 
 // Try to load config from server (non-blocking)
-loadConfigFromServer().then(serverConfig => {
-  if (serverConfig) {
-    applyConfig(serverConfig);       // <— single point of truth
-    console.log('[Config] hydrated from server');
-  } else {
-    console.log('[Config] using defaults');
-  }
-  
-  // Mark initial load as complete after loading from server
-  initialLoadComplete = true;
-}).catch(error => {
-  console.error('Error during initial config load:', error);
-  // Mark as complete even on error, so we can start saving changes
-  initialLoadComplete = true;
-});
+loadConfigFromServer()
+  .then((serverConfig) => {
+    if (serverConfig) {
+      applyConfig(serverConfig) // <— single point of truth
+      console.log('[Config] hydrated from server')
+    } else {
+      console.log('[Config] using defaults')
+    }
+
+    // Mark initial load as complete after loading from server
+    initialLoadComplete = true
+  })
+  .catch((error) => {
+    console.error('Error during initial config load:', error)
+    // Mark as complete even on error, so we can start saving changes
+    initialLoadComplete = true
+  })
 
 // Separate store for WORK_START_DATE as string components
 export const workStartDate = writable({
   year: new Date().getFullYear(),
   month: new Date().getMonth() + 1, // 1-indexed for UI
-  day: new Date().getDate()
-});
+  day: new Date().getDate(),
+})
 
 // Store for chat messages
-export const chatMessages = writable([]);
+export const chatMessages = writable([])
 
 // Set up subscriptions to save configuration on changes
 userConfig.subscribe(() => {
   if (initialLoadComplete) {
-    debouncedSaveLocalConfig();
+    debouncedSaveLocalConfig()
   }
-});
+})
 
 editableTheme.subscribe(() => {
   if (initialLoadComplete) {
-    debouncedSaveLocalConfig();
+    debouncedSaveLocalConfig()
   }
-});
+})
 
 chatMessages.subscribe(() => {
   if (initialLoadComplete) {
-    debouncedSaveLocalConfig();
+    debouncedSaveLocalConfig()
   }
-});
+})
 
 workStartDate.subscribe(() => {
   if (initialLoadComplete) {
-    debouncedSaveLocalConfig();
+    debouncedSaveLocalConfig()
   }
-});
+})
 
 /**
  * Get a complete configuration object for the preview
@@ -664,24 +676,32 @@ workStartDate.subscribe(() => {
  */
 export function getPreviewConfiguration() {
   // Get current values from stores
-  let currentConfig;
-  let currentTheme;
-  let currentMessages;
-  let currentWorkDate;
-  
-  userConfig.subscribe(value => { currentConfig = value; })();
-  editableTheme.subscribe(value => { currentTheme = value; })();
-  chatMessages.subscribe(value => { currentMessages = value; })();
-  workStartDate.subscribe(value => { currentWorkDate = value; })();
-  
+  let currentConfig
+  let currentTheme
+  let currentMessages
+  let currentWorkDate
+
+  userConfig.subscribe((value) => {
+    currentConfig = value
+  })()
+  editableTheme.subscribe((value) => {
+    currentTheme = value
+  })()
+  chatMessages.subscribe((value) => {
+    currentMessages = value
+  })()
+  workStartDate.subscribe((value) => {
+    currentWorkDate = value
+  })()
+
   return {
     profile: {
       ...currentConfig.profile,
       WORK_START_DATE: {
         year: currentWorkDate.year,
         month: currentWorkDate.month,
-        day: currentWorkDate.day
-      }
+        day: currentWorkDate.day,
+      },
     },
     activeTheme: currentConfig.activeTheme,
     avatars: currentConfig.avatars,
@@ -690,7 +710,7 @@ export function getPreviewConfiguration() {
     chatMessages: currentMessages,
     themeOverrides: currentTheme,
     layoutAnimationOverrides: {
-      SCROLL_SPEED_MULTIPLIER: currentConfig.layout?.ANIMATION?.SCROLL_SPEED_MULTIPLIER || 1.0
-    }
-  };
+      SCROLL_SPEED_MULTIPLIER: currentConfig.layout?.ANIMATION?.SCROLL_SPEED_MULTIPLIER || 1.0,
+    },
+  }
 }


### PR DESCRIPTION
## Security fix (P0 — preview server hardening, part 3 / final)

Completes the preview-server remediation. Builds on **#13** (loopback bind) and **#14** (strict CORS + CSRF + validation + GitHub allow-list). Off clean `main` — standalone PR.

Closes the residual gap PR-1b intentionally left (loopback no-Origin tooling could still perform state changes) and hardens the **opt-in external-bind** path: even there, a LAN caller can neither obtain nor forge the token.

### Token threat model
- Server mints a **per-process** CSPRNG token.
- `GET /preview-token` returns it **only to loopback callers** (`Host` check) **and** CORS-restricted to the configurator origin. A LAN attacker reaches the server via its routable IP → `Host` isn't loopback → 403; a foreign browser page can't read the response → CORS. No Vite/file coupling, no startup race.
- State-changing endpoints (the 3 POSTs + token-backed `GET /api/github/user-repos`) require a valid `X-Preview-Token` (**401**) on top of the origin/CSRF check (**403**), via `authorizeStateChange()` (origin first → 403, then token → 401). Constant-time token comparison.

### Changes
**Server:** `serverAuth.js` (token mint, loopback-Host gate, constant-time check); `GET /preview-token`; token enforcement; `X-Preview-Token` allowed in CORS.
**SPA:** `previewToken.js` (fetch-once + cache + retry); token attached to every state-changing call (`configStore` save-local-config, `GitHubSaveUIManager` user-repos + save-config, `SvgPreviewRenderer` generate-preview, `ServerTest`).

> The `style:` commit is an **isolated, mechanical** prettier reformat of `configStore.js` (the SPA files predate the repo's `semi:false` config). Keeps the security diff reviewable. No `.svelte` reformat (no prettier-svelte plugin).

### Tests & acceptance
- `vitest run`: **476 pass** (new: serverAuth 10, authorizeStateChange 5, previewToken 3). `eslint .` clean.
- [x] Existing local configurator flow still works.
- [x] Foreign-origin requests can't read the token or perform state changes.
- [x] LAN callers on opt-in external bind can't obtain the token via `/preview-token`.
- [x] Missing/invalid token rejected (401); valid token happy path works.

### Manual verification (booted server)
| Check | Result |
|---|---|
| `GET /preview-token` from loopback (origin localhost:5173) | 200 + 64-char token |
| `GET /preview-token` with spoofed non-loopback `Host` | **403** |
| state change, allowed origin, **no** token | **401** |
| state change, allowed origin, **valid** token, bad body | 400 (auth passed → validation) |
| state change, **foreign** origin + token | **403** (origin checked first) |
| **End-to-end SPA flow:** fetch token (origin localhost:5173) → `POST /generate-preview` with token | **200 + `<svg>`** |

### Note for the PM
Per your direction, **PR-4 (CI verify gate) should come next** so normal merges stop requiring owner override (these PRs don't trigger the `build` check due to the `pull_request.paths` gap). I'll resequence: PR-4 → PR-2 (license) → PR-3 (workspaces) → PR-5 (reliability spine).
