### PR TITLE
ci: always-on required verify gate + coverage thresholds (PR-4)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,48 @@
+name: Verify
+
+# Always-on quality gate for every PR (and pushes to main). Deliberately has NO
+# `paths` filter so changes to configurator-ui/**, tests/**, vitest.config.js,
+# workflows, docs, or config can never skip lint/tests — the gap that previously
+# forced owner-admin merges. The path-filtered build/generate/commit pipeline
+# stays in main.yml.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Tests + coverage (deterministic)
+        run: npx vitest run --coverage
+
+      - name: Secret scan (gitleaks)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
@@ -19,8 +19,16 @@ export default defineConfig({
         'src/config/config.js', // This is mostly data, but ConfigValidator tests will use it indirectly
       ],
       all: true, // Attempt to include all files from `include` in report, even if no tests yet
+      // Ratcheting floor for src/** (currently ~90.5% stmts / 85.7% branch / 98% funcs).
+      // Set conservatively below current to lock in the gain without flakiness; raise over time.
+      thresholds: {
+        statements: 85,
+        branches: 80,
+        functions: 95,
+        lines: 85,
+      },
     },
     // Optional: if we need global setup for mocks later
-    // setupFiles: ['./tests/setupTests.js'], 
+    // setupFiles: ['./tests/setupTests.js'],
   },
-});
+})


### PR DESCRIPTION
## CI: always-on required `verify` gate (retires owner-admin override)

Fixes the merge-gate gap (forensics `gapfill-03`) that forced owner `--admin` merges for the security PRs: `main.yml`'s `pull_request.paths` filter excludes `configurator-ui/**`, `tests/**`, `vitest.config.js`, and workflows, so PRs touching only those ran **neither lint nor tests**, and the required `build` check never reported.

### Changes
- **New `.github/workflows/verify.yml`** — runs on **every** `pull_request` (no `paths` filter) and on push to `main`:
  - `npm ci` → `npm run lint` → `npx vitest run --coverage` (deterministic) → **gitleaks** secret scan.
  - Least-privilege (`contents: read`), concurrency-cancel.
- **`vitest.config.js`** — ratcheting coverage thresholds for `src/**` (85/80/95/85, set below current 90.5/85.7/98.2/90.5 to lock the gain without flakiness).
- `main.yml` (path-filtered build → generate → commit) is **unchanged**.

### After merge (I'll do this)
Switch branch protection's required status check from `build` → **`verify`**, so the path-filtered build no longer gates unrelated PRs. **This retires owner-admin override as a process.**

### Scope discipline (deferred, not ballooned)
- **Configurator-tree CI** (`npm ci` + Vite build for `configurator-ui/`) is blocked by the configurator **lockfile drift** (`dependencies-001`) — lands with **PR-3 (workspaces)**. Root `vitest` already runs the configurator server/lib tests and `eslint .` lints the whole repo, so the gate is meaningful now.
- **Repo-wide `prettier --check`** needs a one-time format pass (the SPA files predate `semi:false`) — separate style PR, to avoid turning this into a cleanup.

### Note on merging THIS PR
PR-4 changes only `.github/**` + `vitest.config.js`, still outside `main.yml`'s path filter, so the old `build` check won't report and this PR will be `BLOCKED` — the **final** documented owner-override. Once it lands and protection requires `verify`, normal merges work.

### Local verification
`npm run lint` clean; `npx vitest run --coverage` = **476 pass**, 90.5% stmts (above threshold). `verify.yml` runs on this PR itself (same-repo PR uses the branch's workflow), so its first real execution is visible here.
