### PR TITLE
docs: normalize license to MIT + add NOTICE (PR-2)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,21 @@
-# This is free and unencumbered software released into the public domain
+MIT License
 
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
+Copyright (c) 2025 Dan Johnson
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-For more information, please refer to <https://unlicense.org>
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,40 @@
+ProfileChatter
+Copyright (c) 2025 Dan Johnson
+
+This product is licensed under the MIT License (see LICENSE).
+
+It includes the following third-party materials:
+
+--------------------------------------------------------------------------------
+Inter (font)
+--------------------------------------------------------------------------------
+A subset of the Inter typeface is embedded as base64 WOFF2 in
+`src/rendering/fontData.js` and is rendered into the generated SVG output.
+
+  - Project: Inter — https://github.com/rsms/inter
+  - License: SIL Open Font License, Version 1.1
+            https://opensource.org/license/ofl-1-1
+  - Copyright: Copyright (c) 2016 The Inter Project Authors
+              (https://github.com/rsms/inter)
+
+The SIL OFL permits embedding the font in documents/output. The font is used
+here only as embedded glyph data for rendering text in the generated SVG.
+
+--------------------------------------------------------------------------------
+Programming-language colors
+--------------------------------------------------------------------------------
+The language-to-color mapping in `src/services/utils/languageColors.js` is based
+on GitHub's language color scheme, as published in GitHub Linguist.
+
+  - Source: GitHub Linguist (languages.yml)
+            https://github.com/github-linguist/linguist
+  - License: MIT License
+
+The values in this repository were transcribed/curated by hand from that scheme;
+if any color diverges from the upstream source, the upstream value should be
+treated as authoritative.
+
+--------------------------------------------------------------------------------
+
+No other third-party assets or data are bundled in this repository. Runtime
+npm dependencies retain their own licenses as declared in their packages.

--- a/README.md
+++ b/README.md
@@ -379,7 +379,10 @@ PRs are welcome! We have a comprehensive test suite (~400+ tests) integrated int
 
 ## 📝 License
 
-[UNLICENSE](LICENSE) – public domain, no strings attached.
+[MIT](LICENSE) © 2025 Dan Johnson.
+
+Third-party materials bundled or embedded in the output (the Inter font and
+GitHub language colors) are credited in [NOTICE](NOTICE).
 
 ---
 


### PR DESCRIPTION
## docs/legal: normalize license to MIT + add NOTICE

Clears the documentation Critical (forensics `documentation-001`): the project had a **three-way license contradiction** — `LICENSE` was Unlicense text, `package.json` said MIT, `README` said UNLICENSE. Downstream users couldn't tell their obligations.

### Changes
- **`LICENSE`** → standard MIT text, `Copyright (c) 2025 Dan Johnson`.
- **`README.md`** license section → **MIT** (links `LICENSE`) + pointer to `NOTICE`.
- **`package.json`** → already `"MIT"` (unchanged).
- **`NOTICE`** (new) → credits the third-party materials actually present:
  - **Inter font** embedded as base64 in `src/rendering/fontData.js` → SIL Open Font License 1.1 (rsms/inter).
  - **Language colors** in `src/services/utils/languageColors.js` → based on **GitHub Linguist** (`languages.yml`), MIT; file header already states "based on GitHub's language color scheme."

Per the PM's note, attribution is **not over-invented** — only materials bundled/embedded are listed, with confirmed upstream sources. `configurator-ui/package.json` is `private` (no license field) and left as-is.

### Acceptance
- [x] GitHub will detect the repo license as **MIT** (standard MIT body in `LICENSE`).
- [x] npm/package metadata says MIT.
- [x] README says MIT and links `LICENSE`.
- [x] `LICENSE` is internally consistent (pure MIT).
- [x] `NOTICE` identifies third-party materials + sources/licenses.
- [x] No runtime behavior changes; no dependency/workspace changes; no reliability work.
- [x] `verify` runs on this PR (first PR fully gated by the new required check).

### Local verification
`npm run lint` clean; `npx vitest run` = **476 pass**. Doc-only diff (LICENSE rewrite, README +4/-1, new NOTICE).
