### PR TITLE
feat(reliability): shared HTTP client + discriminated source results (PR-5a)

### DIFF
--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -15,6 +15,10 @@ import DateTimeFormatService from './DateTimeFormatService.js'
 
 /* ---------- service ------------------------------------------------------ */
 class DataService {
+  // Per-run health of the discriminated sources (github, githubOAuth); consumed
+  // by PR-5b's status manifest / staleness guard. Empty until the first run.
+  lastSourceStatuses = []
+
   async getDynamicData(customData = {}) {
     // initialise base object so we have something even on catastrophic failure
     let baseData = {
@@ -93,7 +97,32 @@ class DataService {
             getSpotifyData(),
             getGitHubOAuthData(),
           ])
-        Object.assign(baseData, weather, github, wakatime, codestats, spotify, githubOAuth)
+        // github + githubOAuth return discriminated results { status, value, error, fetchedAt }.
+        // Unwrap their values for rendering and record per-source status so PR-5b can build a
+        // staleness manifest — a fallback is no longer indistinguishable from live data.
+        Object.assign(
+          baseData,
+          weather,
+          github.value || {},
+          wakatime,
+          codestats,
+          spotify,
+          githubOAuth.value || {}
+        )
+        this.lastSourceStatuses = [
+          {
+            source: 'github',
+            status: github.status,
+            error: github.error,
+            fetchedAt: github.fetchedAt,
+          },
+          {
+            source: 'githubOAuth',
+            status: githubOAuth.status,
+            error: githubOAuth.error,
+            fetchedAt: githubOAuth.fetchedAt,
+          },
+        ]
 
         // Handle Twitter followers with manual input priority
         if (customData.profile?.TWITTER_FOLLOWERS) {

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -4,10 +4,10 @@
  * Single Responsibility: Data orchestration and formatting
  */
 import { config } from '../config/config.js'
-import { getGitHubData }   from './data_sources/githubDataSource.js'
-import { getWeatherData }  from './data_sources/weatherDataSource.js'
+import { getGitHubData } from './data_sources/githubDataSource.js'
+import { getWeatherData } from './data_sources/weatherDataSource.js'
 import { getWakaTimeData } from './data_sources/wakatimeDataSource.js'
-import { getTwitterData }  from './data_sources/twitterDataSource.js'
+import { getTwitterData } from './data_sources/twitterDataSource.js'
 import { getCodeStatsData } from './data_sources/codestatsDataSource.js'
 import { getSpotifyData } from './data_sources/spotifyDataSource.js'
 import { getGitHubOAuthData } from './data_sources/githubOAuthDataSource.js'
@@ -15,101 +15,101 @@ import DateTimeFormatService from './DateTimeFormatService.js'
 
 /* ---------- service ------------------------------------------------------ */
 class DataService {
-  async getDynamicData (customData = {}) {
+  async getDynamicData(customData = {}) {
     // initialise base object so we have something even on catastrophic failure
     let baseData = {
       currentDayOfWeek: 'N/A',
-      currentDate:      'N/A',
-      dayName:          'N/A',
-      dayNameShort:     'N/A',
-      monthName:        'N/A',
-      monthNameShort:   'N/A',
-      day:              'N/A',
-      year:             'N/A',
-      time:             'N/A',
-      time24:           'N/A',
-      dateTime:         'N/A',
-      timezone:         'N/A',
-      timezoneAbbr:     'N/A',
-      workTenure:       'N/A',
+      currentDate: 'N/A',
+      dayName: 'N/A',
+      dayNameShort: 'N/A',
+      monthName: 'N/A',
+      monthNameShort: 'N/A',
+      day: 'N/A',
+      year: 'N/A',
+      time: 'N/A',
+      time24: 'N/A',
+      dateTime: 'N/A',
+      timezone: 'N/A',
+      timezoneAbbr: 'N/A',
+      workTenure: 'N/A',
       // API defaults
-      temperature:        config.apiDefaults.TEMPERATURE,
+      temperature: config.apiDefaults.TEMPERATURE,
       weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
-      emoji:              config.apiDefaults.WEATHER_EMOJI,
-      githubPublicRepos:  config.apiDefaults.GITHUB_PUBLIC_REPOS,
-      githubFollowers:    config.apiDefaults.GITHUB_FOLLOWERS,
-      twitterFollowers:   config.apiDefaults.TWITTER_FOLLOWERS,
-      codestatsXP:        config.apiDefaults.CODESTATS_XP,
-      spotifyTrack:       config.apiDefaults.SPOTIFY_NOW_PLAYING,
+      emoji: config.apiDefaults.WEATHER_EMOJI,
+      githubPublicRepos: config.apiDefaults.GITHUB_PUBLIC_REPOS,
+      githubFollowers: config.apiDefaults.GITHUB_FOLLOWERS,
+      twitterFollowers: config.apiDefaults.TWITTER_FOLLOWERS,
+      codestatsXP: config.apiDefaults.CODESTATS_XP,
+      spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING,
       // Add new GitHub OAuth defaults
-      githubTotalStars:     config.apiDefaults.GITHUB_TOTAL_STARS,
+      githubTotalStars: config.apiDefaults.GITHUB_TOTAL_STARS,
       githubCommitsLastYear: config.apiDefaults.GITHUB_COMMITS_LAST_YEAR,
       githubContributedRepos: config.apiDefaults.GITHUB_CONTRIBUTED_REPOS,
       githubPrimaryLanguage: config.apiDefaults.GITHUB_PRIMARY_LANGUAGE,
       // static profile
-      name:           config.profile.NAME,
-      profession:     config.profile.PROFESSION,
-      location:       config.profile.LOCATION,
-      company:        config.profile.COMPANY,
+      name: config.profile.NAME,
+      profession: config.profile.PROFESSION,
+      location: config.profile.LOCATION,
+      company: config.profile.COMPANY,
       currentProject: config.profile.CURRENT_PROJECT,
       // WakaTime fallback
-      wakatime_summary:              config.wakatime.defaults.wakatime_summary,
-      wakatime_top_language:         config.wakatime.defaults.wakatime_top_language,
-      wakatime_top_language_percent: config.wakatime.defaults.wakatime_top_language_percent
+      wakatime_summary: config.wakatime.defaults.wakatime_summary,
+      wakatime_top_language: config.wakatime.defaults.wakatime_top_language,
+      wakatime_top_language_percent: config.wakatime.defaults.wakatime_top_language_percent,
     }
 
     try {
       // Get timezone from configuration
-      const effectiveTimeZone = customData.profile?.TIMEZONE || config.profile.TIMEZONE || 'UTC';
-      
+      const effectiveTimeZone = customData.profile?.TIMEZONE || config.profile.TIMEZONE || 'UTC'
+
       // Use the DateTimeFormatService to get all date/time formatted values
       try {
-        const dateTimeData = DateTimeFormatService.formatCurrentDateTime(effectiveTimeZone);
-        
+        const dateTimeData = DateTimeFormatService.formatCurrentDateTime(effectiveTimeZone)
+
         // Merge all date/time data into baseData
-        Object.assign(baseData, dateTimeData);
-        
-        console.log(`DataService: Using timezone "${effectiveTimeZone}" for date formatting.`);
+        Object.assign(baseData, dateTimeData)
+
+        console.log(`DataService: Using timezone "${effectiveTimeZone}" for date formatting.`)
       } catch (e) {
-        console.warn(`DataService: Error formatting date/time: ${e.message}`);
-        
+        console.warn(`DataService: Error formatting date/time: ${e.message}`)
+
         // If there's an error, try with UTC
-        const utcDateTimeData = DateTimeFormatService.formatCurrentDateTime('UTC');
-        Object.assign(baseData, utcDateTimeData);
+        const utcDateTimeData = DateTimeFormatService.formatCurrentDateTime('UTC')
+        Object.assign(baseData, utcDateTimeData)
       }
-      
+
       // First use the default work start date from config
-      let workStartDate = config.profile.WORK_START_DATE;
-      
+      let workStartDate = config.profile.WORK_START_DATE
+
       /* remote */
       try {
-        const [weather, github, wakatime, twitter, codestats, spotify, githubOAuth] = await Promise.all([
-          getWeatherData(),
-          getGitHubData(),
-          getWakaTimeData(),
-          getTwitterData(),
-          getCodeStatsData(),
-          getSpotifyData(),
-          getGitHubOAuthData()
-        ]);
-        Object.assign(baseData, weather, github, wakatime, codestats, spotify, githubOAuth);
+        const [weather, github, wakatime, twitter, codestats, spotify, githubOAuth] =
+          await Promise.all([
+            getWeatherData(),
+            getGitHubData(),
+            getWakaTimeData(),
+            getTwitterData(),
+            getCodeStatsData(),
+            getSpotifyData(),
+            getGitHubOAuthData(),
+          ])
+        Object.assign(baseData, weather, github, wakatime, codestats, spotify, githubOAuth)
 
         // Handle Twitter followers with manual input priority
         if (customData.profile?.TWITTER_FOLLOWERS) {
           // Prioritize customData.profile.TWITTER_FOLLOWERS (from UI/profileChatterConfig.json)
-          baseData.twitterFollowers = customData.profile.TWITTER_FOLLOWERS;
+          baseData.twitterFollowers = customData.profile.TWITTER_FOLLOWERS
         } else if (config.profile.TWITTER_FOLLOWERS) {
           // Then config.profile.TWITTER_FOLLOWERS (from src/config/config.js)
-          baseData.twitterFollowers = config.profile.TWITTER_FOLLOWERS;
+          baseData.twitterFollowers = config.profile.TWITTER_FOLLOWERS
         } else if (config.twitter.enabled_api_fetch && twitter.twitterFollowers) {
           // Then, if API fetching is enabled and successful, use that value
-          baseData.twitterFollowers = twitter.twitterFollowers;
+          baseData.twitterFollowers = twitter.twitterFollowers
         }
         // Finally, fall back to config.apiDefaults.TWITTER_FOLLOWERS (already set above)
-
       } catch (apiErr) {
-        console.error('Error fetching APIs:', apiErr.message);
-        console.info('Using defaults already in baseData.');
+        console.error('Error fetching APIs:', apiErr.message)
+        console.info('Using defaults already in baseData.')
       }
 
       // Map nested profile overrides to the expected lowercase keys
@@ -120,42 +120,47 @@ class DataService {
         if (typeof p.LOCATION === 'string') baseData.location = p.LOCATION
         if (typeof p.COMPANY === 'string') baseData.company = p.COMPANY
         if (typeof p.CURRENT_PROJECT === 'string') baseData.currentProject = p.CURRENT_PROJECT
-        
+
         // Check if we have a custom work start date to use
         if (p.WORK_START_DATE) {
           // If it's an object with year, month, day properties (from UI)
-          if (typeof p.WORK_START_DATE === 'object' && 
-              p.WORK_START_DATE.year !== undefined &&
-              p.WORK_START_DATE.month !== undefined &&
-              p.WORK_START_DATE.day !== undefined) {
-            
-            const year = parseInt(p.WORK_START_DATE.year, 10);
-            const month = parseInt(p.WORK_START_DATE.month, 10); // UI month is 1-indexed
-            const day = parseInt(p.WORK_START_DATE.day, 10);
-            
+          if (
+            typeof p.WORK_START_DATE === 'object' &&
+            p.WORK_START_DATE.year !== undefined &&
+            p.WORK_START_DATE.month !== undefined &&
+            p.WORK_START_DATE.day !== undefined
+          ) {
+            const year = parseInt(p.WORK_START_DATE.year, 10)
+            const month = parseInt(p.WORK_START_DATE.month, 10) // UI month is 1-indexed
+            const day = parseInt(p.WORK_START_DATE.day, 10)
+
             if (!isNaN(year) && !isNaN(month) && !isNaN(day)) {
               // Create a new Date object (JS months are 0-indexed)
-              workStartDate = new Date(year, month - 1, day);
-              console.log(`Using custom work start date: ${workStartDate.toDateString()}`);
+              workStartDate = new Date(year, month - 1, day)
+              console.log(`Using custom work start date: ${workStartDate.toDateString()}`)
             }
           }
           // If it's already a Date object
           else if (p.WORK_START_DATE instanceof Date) {
-            workStartDate = p.WORK_START_DATE;
-            console.log(`Using Date object from profile.WORK_START_DATE: ${workStartDate.toDateString()}`);
+            workStartDate = p.WORK_START_DATE
+            console.log(
+              `Using Date object from profile.WORK_START_DATE: ${workStartDate.toDateString()}`
+            )
           }
         }
       }
-      
+
       // Also check if customData.workStartDate exists (how previewServer.js passes it)
       if (customData.workStartDate instanceof Date) {
-        workStartDate = customData.workStartDate;
-        console.log(`Using Date object from customData.workStartDate: ${workStartDate.toDateString()}`);
+        workStartDate = customData.workStartDate
+        console.log(
+          `Using Date object from customData.workStartDate: ${workStartDate.toDateString()}`
+        )
       }
-      
+
       // Calculate workTenure using the DateTimeFormatService
-      baseData.workTenure = DateTimeFormatService.formatWorkTenure(workStartDate);
-      
+      baseData.workTenure = DateTimeFormatService.formatWorkTenure(workStartDate)
+
       return { ...baseData, ...customData }
     } catch (err) {
       console.error('Critical error in getDynamicData:', err.message)

--- a/src/services/data_sources/githubDataSource.js
+++ b/src/services/data_sources/githubDataSource.js
@@ -1,115 +1,50 @@
 /**
  * githubDataSource.js
- * Responsible for fetching and caching GitHub user data
- * Single Responsibility: GitHub data acquisition
+ * Single Responsibility: GitHub public data acquisition (repos, followers)
+ *
+ * Returns a discriminated source result (see sourceResult.js): `ok` with live
+ * values, or `fallback` carrying config defaults AND the error — so the
+ * orchestrator can tell live data from a quiet fallback.
  */
-import { config } from '../../config/config.js';
+import { config } from '../../config/config.js'
+import { fetchJson } from '../utils/httpClient.js'
+import { ok, fallback } from '../utils/sourceResult.js'
 
-// Initialize module-level cache store
-let githubCache = { data: null, expiresAt: 0 };
+// Module-level cache of the last successful (ok) result.
+let githubCache = { result: null, expiresAt: 0 }
 
 /**
- * Fetch GitHub user data with robust error handling and caching
- * @returns {Promise<Object>} - GitHub data (repos, followers)
+ * @param {object} [deps] - optional injectables forwarded to fetchJson
+ *   (fetchImpl, sleep, timeoutMs, retries) — used by tests; production calls
+ *   getGitHubData() with no args and uses the defaults.
+ * @returns {Promise<import('../utils/sourceResult.js').SourceResult>}
  */
-async function getGitHubData() {
+async function getGitHubData(deps = {}) {
+  if (githubCache.result && Date.now() < githubCache.expiresAt) {
+    return githubCache.result
+  }
+
+  const username = config.profile.GITHUB_USERNAME
+  const defaults = {
+    githubPublicRepos: config.apiDefaults.GITHUB_PUBLIC_REPOS,
+    githubFollowers: config.apiDefaults.GITHUB_FOLLOWERS,
+  }
+
   try {
-    // Check if valid cached data exists
-    if (githubCache.data && Date.now() < githubCache.expiresAt) {
-      console.info('Using cached GitHub data.');
-      return githubCache.data;
-    }
-
-    const username = config.profile.GITHUB_USERNAME;
-    
-    // For browser environments
-    if (typeof fetch === 'function') {
-      const response = await fetch(`https://api.github.com/users/${username}`, {
-        headers: { 'Accept': 'application/vnd.github.v3+json' }
-      });
-      
-      if (!response.ok) {
-        // Handle specific HTTP error status codes
-        switch (response.status) {
-          case 401:
-            throw new Error(`GitHub API error (${response.status}): Unauthorized. If you're using a GitHub token, it may be invalid.`);
-          case 403:
-          case 429:
-            throw new Error(`GitHub API error (${response.status}): Rate limit exceeded. Consider adding a PAT_GITHUB_BASIC to your environment variables to increase your rate limit.`);
-          case 404:
-            throw new Error(`GitHub API error (${response.status}): User '${username}' not found. Check the GITHUB_USERNAME in your config.`);
-          default:
-            throw new Error(`GitHub API server error (${response.status}): ${response.statusText}`);
-        }
-      }
-      
-      const data = await response.json();
-      
-      const result = {
-        githubPublicRepos: data.public_repos.toString(),
-        githubFollowers: data.followers.toString()
-      };
-
-      // Cache the successful API response
-      githubCache.data = result;
-      githubCache.expiresAt = Date.now() + config.cache.GITHUB_CACHE_TTL_MS;
-      console.info('GitHub data fetched from API and cached.');
-      
-      return result;
-    } 
-    else {
-      // Node.js environment - try with node-fetch
-      try {
-        const { default: fetch } = await import('node-fetch');
-        const response = await fetch(`https://api.github.com/users/${username}`, {
-          headers: { 'Accept': 'application/vnd.github.v3+json' }
-        });
-        
-        if (!response.ok) {
-          // Handle specific HTTP error status codes
-          switch (response.status) {
-            case 401:
-              throw new Error(`GitHub API error (${response.status}): Unauthorized. If you're using a GitHub token, it may be invalid.`);
-            case 403:
-            case 429:
-              throw new Error(`GitHub API error (${response.status}): Rate limit exceeded. Consider adding a PAT_GITHUB_BASICto your environment variables to increase your rate limit.`);
-            case 404:
-              throw new Error(`GitHub API error (${response.status}): User '${username}' not found. Check the GITHUB_USERNAME in your config.`);
-            default:
-              throw new Error(`GitHub API server error (${response.status}): ${response.statusText}`);
-          }
-        }
-        
-        const data = await response.json();
-        
-        const result = {
-          githubPublicRepos: data.public_repos.toString(),
-          githubFollowers: data.followers.toString()
-        };
-
-        // Cache the successful API response
-        githubCache.data = result;
-        githubCache.expiresAt = Date.now() + config.cache.GITHUB_CACHE_TTL_MS;
-        console.info('GitHub data fetched from API and cached.');
-        
-        return result;
-      } catch (error) {
-        console.error('Error fetching GitHub data in Node environment:', error.message);
-        console.info('Using default GitHub data due to API error.');
-        return {
-          githubPublicRepos: config.apiDefaults.GITHUB_PUBLIC_REPOS,
-          githubFollowers: config.apiDefaults.GITHUB_FOLLOWERS
-        };
-      }
-    }
+    const data = await fetchJson(`https://api.github.com/users/${username}`, {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+      ...deps,
+    })
+    const result = ok({
+      githubPublicRepos: data.public_repos.toString(),
+      githubFollowers: data.followers.toString(),
+    })
+    githubCache = { result, expiresAt: Date.now() + config.cache.GITHUB_CACHE_TTL_MS }
+    return result
   } catch (error) {
-    console.error('Error fetching GitHub data:', error.message);
-    console.info('Using default GitHub data due to API error.');
-    return {
-      githubPublicRepos: config.apiDefaults.GITHUB_PUBLIC_REPOS,
-      githubFollowers: config.apiDefaults.GITHUB_FOLLOWERS
-    };
+    console.warn(`GitHub data unavailable, using defaults: ${error.message}`)
+    return fallback(defaults, error)
   }
 }
 
-export { getGitHubData };
+export { getGitHubData }

--- a/src/services/data_sources/githubOAuthDataSource.js
+++ b/src/services/data_sources/githubOAuthDataSource.js
@@ -1,207 +1,127 @@
 /**
  * githubOAuthDataSource.js
- * Responsible for fetching and caching GitHub user data using OAuth token
- * Single Responsibility: GitHub OAuth data acquisition
+ * Single Responsibility: GitHub OAuth data acquisition (stars, commits, repos, language)
+ *
+ * Returns a discriminated source result (see sourceResult.js): `ok` with live
+ * values, or `fallback` carrying config defaults AND the error.
+ *
+ * Note: the "commits last year" value is a best-effort estimate from recent
+ * public events; it is replaced by the GraphQL contributionsCollection in PR-5c.
  */
-import { config } from '../../config/config.js';
-import githubOAuthService from '../auth/githubOAuthService.js';
+import { config } from '../../config/config.js'
+import githubOAuthService from '../auth/githubOAuthService.js'
+import { fetchJson } from '../utils/httpClient.js'
+import { ok, fallback } from '../utils/sourceResult.js'
 
-// Initialize module-level cache store
-let githubOAuthCache = { data: null, expiresAt: 0 };
+let githubOAuthCache = { result: null, expiresAt: 0 }
+
+const oauthDefaults = () => ({
+  githubTotalStars: config.apiDefaults.GITHUB_TOTAL_STARS,
+  githubCommitsLastYear: config.apiDefaults.GITHUB_COMMITS_LAST_YEAR,
+  githubContributedRepos: config.apiDefaults.GITHUB_CONTRIBUTED_REPOS,
+  githubPrimaryLanguage: config.apiDefaults.GITHUB_PRIMARY_LANGUAGE,
+})
 
 /**
- * Fetch GitHub user data with OAuth authentication
- * Supports both interactive OAuth flow and CI mode with direct token
- * @returns {Promise<Object>} - Enhanced GitHub data (stars, commits, etc.)
+ * @param {object} [deps] - optional injectables forwarded to fetchJson
+ *   (fetchImpl, sleep, timeoutMs, retries); production calls with no args.
+ * @returns {Promise<import('../utils/sourceResult.js').SourceResult>}
  */
-async function getGitHubOAuthData() {
+async function getGitHubOAuthData(deps = {}) {
+  if (githubOAuthCache.result && Date.now() < githubOAuthCache.expiresAt) {
+    return githubOAuthCache.result
+  }
+
+  // Acquire access token: CI direct token, otherwise the OAuth service.
+  let accessToken
   try {
-    // Check if valid cached data exists
-    if (githubOAuthCache.data && Date.now() < githubOAuthCache.expiresAt) {
-      console.info('Using cached GitHub OAuth data.');
-      return githubOAuthCache.data;
+    if (process.env.GITHUB_DATA_MODE === 'ci' && process.env.PAT_GITHUB_OAUTH) {
+      accessToken = process.env.PAT_GITHUB_OAUTH
+    } else {
+      accessToken = await githubOAuthService.getAccessToken()
     }
+  } catch (tokenError) {
+    console.warn(`GitHub OAuth token unavailable, using defaults: ${tokenError.message}`)
+    return fallback(oauthDefaults(), tokenError)
+  }
 
-    // Get OAuth access token - with CI mode support
-    let accessToken;
-    try {
-      // First check for CI mode
-      if (process.env.GITHUB_DATA_MODE === 'ci' && process.env.PAT_GITHUB_OAUTH) {
-        console.info('Using CI mode for GitHub data with direct token');
-        accessToken = process.env.PAT_GITHUB_OAUTH;
-      } else {
-        // Regular OAuth flow for local development
-        accessToken = await githubOAuthService.getAccessToken();
-      }
-    } catch (tokenError) {
-      console.warn('GitHub OAuth token not available:', tokenError.message);
-      return {
-        githubTotalStars: config.apiDefaults.GITHUB_TOTAL_STARS,
-        githubCommitsLastYear: config.apiDefaults.GITHUB_COMMITS_LAST_YEAR,
-        githubContributedRepos: config.apiDefaults.GITHUB_CONTRIBUTED_REPOS,
-        githubPrimaryLanguage: config.apiDefaults.GITHUB_PRIMARY_LANGUAGE,
-      };
-    }
+  const headers = {
+    Authorization: `token ${accessToken}`,
+    Accept: 'application/vnd.github.v3+json',
+  }
 
-    // Fetch user data
-    let userData;
-    let fetchFunction = typeof fetch === 'function' ? fetch : (await import('node-fetch')).default;
+  try {
+    const userData = await fetchJson('https://api.github.com/user', { headers, ...deps })
+    const repos = await fetchJson('https://api.github.com/user/repos?per_page=100&sort=updated', {
+      headers,
+      ...deps,
+    })
 
-    const userResponse = await fetchFunction('https://api.github.com/user', {
-      headers: {
-        Authorization: `token ${accessToken}`,
-        Accept: 'application/vnd.github.v3+json',
-      },
-    });
+    // Count only repositories the user actually owns (not forks).
+    const ownedRepos = repos.filter((repo) => !repo.fork && repo.owner.login === userData.login)
+    const totalStars = ownedRepos.reduce((acc, repo) => acc + repo.stargazers_count, 0)
 
-    if (!userResponse.ok) {
-      throw new Error(`GitHub API error (${userResponse.status}): ${userResponse.statusText}`);
-    }
-
-    userData = await userResponse.json();
-    console.info(`GitHub user authenticated: ${userData.login}`);
-
-    // Fetch user's repositories
-    const reposResponse = await fetchFunction(
-      `https://api.github.com/user/repos?per_page=100&sort=updated`,
-      {
-        headers: {
-          Authorization: `token ${accessToken}`,
-          Accept: 'application/vnd.github.v3+json',
-        },
-      }
-    );
-
-    if (!reposResponse.ok) {
-      throw new Error(`GitHub API error (${reposResponse.status}): ${reposResponse.statusText}`);
-    }
-
-    const repos = await reposResponse.json();
-    console.info(`Fetched ${repos.length} repositories from GitHub`);
-
-    // Only count repositories the user actually owns (not forks)
-    const ownedRepos = repos.filter(repo => !repo.fork && repo.owner.login === userData.login);
-    console.info(`Found ${ownedRepos.length} owned non-fork repositories`);
-
-    // Calculate total stars - only count repositories the user owns
-    const totalStars = ownedRepos.reduce((acc, repo) => acc + repo.stargazers_count, 0);
-    console.info(`Total stars across owned repositories: ${totalStars}`);
-
-    // Determine primary language based on most used language in repos
-    const languageCounts = {};
+    const languageCounts = {}
     ownedRepos.forEach((repo) => {
-      if (repo.language) {
-        languageCounts[repo.language] = (languageCounts[repo.language] || 0) + 1;
-      }
-    });
-
-    let primaryLanguage = 'None';
-    let maxCount = 0;
-
+      if (repo.language) languageCounts[repo.language] = (languageCounts[repo.language] || 0) + 1
+    })
+    let primaryLanguage = 'None'
+    let maxCount = 0
     for (const [language, count] of Object.entries(languageCounts)) {
       if (count > maxCount) {
-        maxCount = count;
-        primaryLanguage = language;
+        maxCount = count
+        primaryLanguage = language
       }
     }
-    console.info(`Primary language determined: ${primaryLanguage}`);
 
-    // For contributed repos count, use owned repos count
-    const contributedReposCount = ownedRepos.length;
+    const contributedReposCount = ownedRepos.length
 
-    // For commits count, we'll use a cautious approach based on contribution activity
-    let commitsLastYear = config.apiDefaults.GITHUB_COMMITS_LAST_YEAR; // Default fallback
-
-    // Try to get contribution stats if possible
-    try {
-      const username = userData.login;
-      
-      // Only attempt to get commit data if we have owned repos
-      if (ownedRepos.length > 0) {
-        const statsResponse = await fetchFunction(
-          `https://api.github.com/users/${username}/events?per_page=100`,
-          {
-            headers: {
-              Authorization: `token ${accessToken}`,
-              Accept: 'application/vnd.github.v3+json',
-            },
-          }
-        );
-        
-        if (statsResponse.ok) {
-          const events = await statsResponse.json();
-          console.info(`Found ${events.length} recent GitHub events`);
-          
-          // Only count PushEvents as they contain commits
-          const pushEvents = events.filter(event => event.type === 'PushEvent');
-          console.info(`Found ${pushEvents.length} push events`);
-          
-          if (pushEvents.length > 0) {
-            // Count actual commits from push events
-            let totalCommits = 0;
-            
-            pushEvents.forEach(event => {
-              // Ensure we have payload and size
-              if (event.payload && typeof event.payload.size === 'number') {
-                totalCommits += event.payload.size;
-              }
-            });
-            
-            // Scale up to estimate annual count - but be conservative
-            // Events API typically covers ~90 days, but we'll use 30 days to be safe
-            let estimatedAnnual = Math.round(totalCommits * (365 / 30));
-            
-            // Cap at a reasonable value to avoid ridiculous estimates
-            const maxReasonableAnnualCommits = 3000; // ~8 commits per day max
-            if (estimatedAnnual > maxReasonableAnnualCommits) {
-              console.info(`Capping estimated commits from ${estimatedAnnual} to ${maxReasonableAnnualCommits}`);
-              estimatedAnnual = maxReasonableAnnualCommits;
+    // Best-effort commit estimate from recent public events (replaced in PR-5c).
+    // A failure here degrades only this one value — it does not fail the source.
+    let commitsLastYear = config.apiDefaults.GITHUB_COMMITS_LAST_YEAR
+    if (ownedRepos.length > 0) {
+      try {
+        const events = await fetchJson(
+          `https://api.github.com/users/${userData.login}/events?per_page=100`,
+          { headers, ...deps }
+        )
+        const pushEvents = events.filter((event) => event.type === 'PushEvent')
+        if (pushEvents.length > 0) {
+          let totalCommits = 0
+          pushEvents.forEach((event) => {
+            if (event.payload && typeof event.payload.size === 'number') {
+              totalCommits += event.payload.size
             }
-            
-            // Format with "+" to indicate it's an estimate
-            commitsLastYear = estimatedAnnual <= 0 ? 
-              config.apiDefaults.GITHUB_COMMITS_LAST_YEAR : 
-              estimatedAnnual.toString() + "+";
-              
-            console.info(`Setting commits last year to ${commitsLastYear}`);
-          } else {
-            console.info('No push events found, using default commit count');
+          })
+          let estimatedAnnual = Math.round(totalCommits * (365 / 30))
+          const maxReasonableAnnualCommits = 3000
+          if (estimatedAnnual > maxReasonableAnnualCommits) {
+            estimatedAnnual = maxReasonableAnnualCommits
           }
-        } else {
-          console.warn(`GitHub API returned ${statsResponse.status} for events endpoint`);
+          commitsLastYear =
+            estimatedAnnual <= 0
+              ? config.apiDefaults.GITHUB_COMMITS_LAST_YEAR
+              : estimatedAnnual.toString() + '+'
         }
-      } else {
-        console.info('No owned repos found, using default commit count');
+      } catch (statsError) {
+        console.warn(
+          `GitHub events stats unavailable, using default commit estimate: ${statsError.message}`
+        )
       }
-    } catch (statsError) {
-      console.warn('Error fetching GitHub commit stats:', statsError.message);
-      // Fall back to the default estimate defined in config
     }
 
-    // Create result object
-    const result = {
+    const result = ok({
       githubTotalStars: totalStars.toString(),
       githubCommitsLastYear: commitsLastYear,
       githubContributedRepos: contributedReposCount.toString(),
       githubPrimaryLanguage: primaryLanguage,
-    };
-
-    // Cache the successful API response
-    githubOAuthCache.data = result;
-    githubOAuthCache.expiresAt = Date.now() + config.cache.GITHUB_OAUTH_CACHE_TTL_MS;
-    console.info('GitHub OAuth data fetched from API and cached.');
-
-    return result;
+    })
+    githubOAuthCache = { result, expiresAt: Date.now() + config.cache.GITHUB_OAUTH_CACHE_TTL_MS }
+    return result
   } catch (error) {
-    console.error('Error fetching GitHub OAuth data:', error.message);
-    console.info('Using default GitHub OAuth data due to API error.');
-    return {
-      githubTotalStars: config.apiDefaults.GITHUB_TOTAL_STARS,
-      githubCommitsLastYear: config.apiDefaults.GITHUB_COMMITS_LAST_YEAR,
-      githubContributedRepos: config.apiDefaults.GITHUB_CONTRIBUTED_REPOS,
-      githubPrimaryLanguage: config.apiDefaults.GITHUB_PRIMARY_LANGUAGE,
-    };
+    console.warn(`GitHub OAuth data unavailable, using defaults: ${error.message}`)
+    return fallback(oauthDefaults(), error)
   }
 }
 
-export { getGitHubOAuthData };
+export { getGitHubOAuthData }

--- a/src/services/utils/httpClient.js
+++ b/src/services/utils/httpClient.js
@@ -1,0 +1,97 @@
+/**
+ * httpClient.js
+ *
+ * Shared outbound HTTP helper for data sources. Provides the reliability
+ * primitives the per-source code previously lacked:
+ *   - per-attempt timeout via AbortSignal.timeout
+ *   - bounded retry with exponential backoff for transient failures
+ *   - explicit fail-fast for auth/config errors (4xx) — never retried
+ *   - normalized errors (HttpError) safe to surface in logs/status
+ *
+ * `fetchImpl` and `sleep` are injectable so the behavior is unit-testable
+ * without real network or real timers.
+ */
+
+export class HttpError extends Error {
+  constructor(status, message, { retryable = false, cause } = {}) {
+    super(message)
+    this.name = 'HttpError'
+    this.status = status
+    this.retryable = retryable
+    if (cause !== undefined) this.cause = cause
+  }
+}
+
+/** Transient statuses worth retrying. Auth/config 4xx are deliberately excluded. */
+export function isRetryableStatus(status) {
+  return status === 408 || status === 425 || status === 429 || (status >= 500 && status <= 599)
+}
+
+function normalizeMessage(err) {
+  if (err && typeof err.message === 'string' && err.message) return err.message
+  return String(err)
+}
+
+/**
+ * Fetch a URL and parse JSON, with timeout + bounded retry/backoff.
+ * Throws HttpError on failure (after exhausting retries, or immediately for
+ * non-retryable statuses).
+ *
+ * @param {string} url
+ * @param {object} [opts]
+ * @param {Record<string,string>} [opts.headers]
+ * @param {number} [opts.timeoutMs=10000]
+ * @param {number} [opts.retries=2]      number of retries AFTER the first attempt
+ * @param {number} [opts.backoffMs=300]  base backoff; grows 1x, 2x, 4x…
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {(ms:number)=>Promise<void>} [opts.sleep]
+ * @returns {Promise<any>}
+ */
+export async function fetchJson(url, opts = {}) {
+  const {
+    headers = {},
+    timeoutMs = 10000,
+    retries = 2,
+    backoffMs = 300,
+    fetchImpl = typeof fetch === 'function' ? fetch : undefined,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  } = opts
+
+  if (typeof fetchImpl !== 'function') {
+    throw new HttpError(0, 'No fetch implementation available', { retryable: false })
+  }
+
+  let attempt = 0
+  for (;;) {
+    try {
+      const res = await fetchImpl(url, { headers, signal: AbortSignal.timeout(timeoutMs) })
+
+      if (res.ok) {
+        return await res.json()
+      }
+
+      const retryable = isRetryableStatus(res.status)
+      if (retryable && attempt < retries) {
+        attempt += 1
+        await sleep(backoffMs * 2 ** (attempt - 1))
+        continue
+      }
+      throw new HttpError(
+        res.status,
+        `HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ''}`.trim(),
+        { retryable }
+      )
+    } catch (err) {
+      // Non-retryable or exhausted status errors are final.
+      if (err instanceof HttpError) throw err
+
+      // Network/timeout (incl. AbortSignal.timeout → TimeoutError) — retryable.
+      if (attempt < retries) {
+        attempt += 1
+        await sleep(backoffMs * 2 ** (attempt - 1))
+        continue
+      }
+      throw new HttpError(0, normalizeMessage(err), { retryable: true, cause: err })
+    }
+  }
+}

--- a/src/services/utils/httpClient.test.js
+++ b/src/services/utils/httpClient.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fetchJson, isRetryableStatus } from './httpClient.js'
+
+const okResponse = (body) => ({ ok: true, status: 200, statusText: 'OK', json: async () => body })
+const errResponse = (status) => ({ ok: false, status, statusText: '', json: async () => ({}) })
+const noSleep = vi.fn().mockResolvedValue(undefined)
+
+describe('isRetryableStatus', () => {
+  it('treats 5xx, 429, 408, 425 as retryable', () => {
+    for (const s of [408, 425, 429, 500, 502, 503, 504]) expect(isRetryableStatus(s)).toBe(true)
+  })
+  it('treats auth/config 4xx as NOT retryable', () => {
+    for (const s of [400, 401, 403, 404]) expect(isRetryableStatus(s)).toBe(false)
+  })
+})
+
+describe('fetchJson', () => {
+  it('returns parsed JSON on success (single call)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(okResponse({ a: 1 }))
+    const data = await fetchJson('https://x', { fetchImpl, sleep: noSleep })
+    expect(data).toEqual({ a: 1 })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries retryable failures with growing backoff, then succeeds', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(errResponse(503))
+      .mockResolvedValueOnce(errResponse(503))
+      .mockResolvedValueOnce(okResponse({ ok: true }))
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    const data = await fetchJson('https://x', { fetchImpl, sleep, retries: 2, backoffMs: 10 })
+    expect(data).toEqual({ ok: true })
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
+    expect(sleep).toHaveBeenCalledTimes(2)
+    expect(sleep.mock.calls[0][0]).toBe(10) // backoff grows
+    expect(sleep.mock.calls[1][0]).toBe(20)
+  })
+
+  it('exhausts retries on persistent retryable failure and throws HttpError', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(errResponse(503))
+    await expect(
+      fetchJson('https://x', { fetchImpl, sleep: noSleep, retries: 2 })
+    ).rejects.toMatchObject({ name: 'HttpError', status: 503, retryable: true })
+    expect(fetchImpl).toHaveBeenCalledTimes(3) // 1 + 2 retries
+  })
+
+  it('does NOT retry an auth error (401) — fails fast', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(errResponse(401))
+    const sleep = vi.fn().mockResolvedValue(undefined)
+    await expect(fetchJson('https://x', { fetchImpl, sleep, retries: 3 })).rejects.toMatchObject({
+      name: 'HttpError',
+      status: 401,
+      retryable: false,
+    })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('does NOT retry a config error (404)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(errResponse(404))
+    await expect(
+      fetchJson('https://x', { fetchImpl, sleep: noSleep, retries: 3 })
+    ).rejects.toMatchObject({ status: 404, retryable: false })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries network/timeout errors then gives up as a retryable HttpError', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'))
+    await expect(
+      fetchJson('https://x', { fetchImpl, sleep: noSleep, retries: 1 })
+    ).rejects.toMatchObject({ name: 'HttpError', retryable: true })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts via AbortSignal timeout when the request hangs', async () => {
+    // fetchImpl resolves only when the abort signal fires (simulates a hung request)
+    const fetchImpl = (url, { signal }) =>
+      new Promise((_, reject) => {
+        if (signal.aborted) reject(signal.reason)
+        signal.addEventListener('abort', () => reject(signal.reason))
+      })
+    await expect(
+      fetchJson('https://x', { fetchImpl, sleep: noSleep, timeoutMs: 20, retries: 0 })
+    ).rejects.toMatchObject({ name: 'HttpError', retryable: true })
+  })
+})

--- a/src/services/utils/sourceResult.js
+++ b/src/services/utils/sourceResult.js
@@ -1,0 +1,44 @@
+/**
+ * sourceResult.js
+ *
+ * Discriminated result type for data sources, so the orchestrator (and PR-5b's
+ * status manifest / staleness guard) can tell live data from a quiet fallback —
+ * eliminating the "green build with invisible fallback values" failure mode.
+ *
+ *   { status: 'ok',       value, fetchedAt }
+ *   { status: 'fallback', value, error, fetchedAt }   // default value served, but a failure occurred
+ *   { status: 'error',    error, fetchedAt }           // no usable value
+ */
+
+/**
+ * Reduce any thrown value to a small, log/status-safe shape (no stack, no
+ * sensitive internals).
+ * @param {unknown} err
+ * @returns {{ message: string, status?: number, retryable?: boolean }}
+ */
+export function normalizeError(err) {
+  if (err == null) return { message: 'Unknown error' }
+  if (typeof err === 'string') return { message: err }
+  const out = {
+    message: typeof err.message === 'string' && err.message ? err.message : String(err),
+  }
+  if (typeof err.status === 'number') out.status = err.status
+  if (typeof err.retryable === 'boolean') out.retryable = err.retryable
+  return out
+}
+
+export function ok(value, fetchedAt = Date.now()) {
+  return { status: 'ok', value, fetchedAt }
+}
+
+export function fallback(value, error, fetchedAt = Date.now()) {
+  return { status: 'fallback', value, error: normalizeError(error), fetchedAt }
+}
+
+export function errored(error, fetchedAt = Date.now()) {
+  return { status: 'error', error: normalizeError(error), fetchedAt }
+}
+
+export function isOk(result) {
+  return !!result && result.status === 'ok'
+}

--- a/src/services/utils/sourceResult.test.js
+++ b/src/services/utils/sourceResult.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { ok, fallback, errored, isOk, normalizeError } from './sourceResult.js'
+import { HttpError } from './httpClient.js'
+
+describe('sourceResult constructors', () => {
+  it('ok() carries the live value and a fetchedAt timestamp', () => {
+    const r = ok({ a: 1 })
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({ a: 1 })
+    expect(typeof r.fetchedAt).toBe('number')
+  })
+
+  it('fallback() carries default value AND the normalized error (distinguishable from ok)', () => {
+    const r = fallback({ a: 0 }, new HttpError(503, 'down', { retryable: true }))
+    expect(r.status).toBe('fallback')
+    expect(r.value).toEqual({ a: 0 })
+    expect(r.error).toEqual({ message: 'down', status: 503, retryable: true })
+  })
+
+  it('errored() carries no value, only the normalized error', () => {
+    const r = errored(new Error('boom'))
+    expect(r.status).toBe('error')
+    expect(r.value).toBeUndefined()
+    expect(r.error.message).toBe('boom')
+  })
+})
+
+describe('isOk', () => {
+  it('is true only for ok results', () => {
+    expect(isOk(ok({}))).toBe(true)
+    expect(isOk(fallback({}, new Error('x')))).toBe(false)
+    expect(isOk(errored(new Error('x')))).toBe(false)
+    expect(isOk(null)).toBe(false)
+  })
+})
+
+describe('normalizeError (log/status-safe)', () => {
+  it('extracts message/status/retryable from an HttpError', () => {
+    expect(normalizeError(new HttpError(401, 'Unauthorized', { retryable: false }))).toEqual({
+      message: 'Unauthorized',
+      status: 401,
+      retryable: false,
+    })
+  })
+  it('handles strings and null', () => {
+    expect(normalizeError('oops')).toEqual({ message: 'oops' })
+    expect(normalizeError(null)).toEqual({ message: 'Unknown error' })
+  })
+  it('does not leak a stack trace', () => {
+    expect(normalizeError(new Error('x')).stack).toBeUndefined()
+  })
+})

--- a/tests/integration/__tests__/ProfileChatter.integration.test.js
+++ b/tests/integration/__tests__/ProfileChatter.integration.test.js
@@ -381,8 +381,8 @@ describe('ProfileChatter Integration Tests', () => {
       })
 
       getGitHubData.mockResolvedValue({
-        githubPublicRepos: '12',
-        githubFollowers: '48',
+        status: 'ok',
+        value: { githubPublicRepos: '12', githubFollowers: '48' },
       })
 
       getSpotifyData.mockResolvedValue({
@@ -404,10 +404,13 @@ describe('ProfileChatter Integration Tests', () => {
       })
 
       getGitHubOAuthData.mockResolvedValue({
-        githubTotalStars: '0',
-        githubCommitsLastYear: '0',
-        githubContributedRepos: '0',
-        githubPrimaryLanguage: 'None',
+        status: 'ok',
+        value: {
+          githubTotalStars: '0',
+          githubCommitsLastYear: '0',
+          githubContributedRepos: '0',
+          githubPrimaryLanguage: 'None',
+        },
       })
 
       const customContext = {
@@ -447,8 +450,8 @@ describe('ProfileChatter Integration Tests', () => {
       })
 
       getGitHubData.mockResolvedValue({
-        githubPublicRepos: '25',
-        githubFollowers: '150',
+        status: 'ok',
+        value: { githubPublicRepos: '25', githubFollowers: '150' },
       })
 
       getSpotifyData.mockResolvedValue({
@@ -470,10 +473,13 @@ describe('ProfileChatter Integration Tests', () => {
       })
 
       getGitHubOAuthData.mockResolvedValue({
-        githubTotalStars: '100',
-        githubCommitsLastYear: '250',
-        githubContributedRepos: '15',
-        githubPrimaryLanguage: 'TypeScript',
+        status: 'ok',
+        value: {
+          githubTotalStars: '100',
+          githubCommitsLastYear: '250',
+          githubContributedRepos: '15',
+          githubPrimaryLanguage: 'TypeScript',
+        },
       })
 
       const customContext = {
@@ -541,8 +547,8 @@ describe('ProfileChatter Integration Tests', () => {
 
       // Mock other data sources to succeed with sample data
       getGitHubData.mockResolvedValue({
-        githubPublicRepos: '20',
-        githubFollowers: '100',
+        status: 'ok',
+        value: { githubPublicRepos: '20', githubFollowers: '100' },
       })
 
       getSpotifyData.mockResolvedValue({
@@ -564,10 +570,13 @@ describe('ProfileChatter Integration Tests', () => {
       })
 
       getGitHubOAuthData.mockResolvedValue({
-        githubTotalStars: '50',
-        githubCommitsLastYear: '150',
-        githubContributedRepos: '10',
-        githubPrimaryLanguage: 'JavaScript',
+        status: 'ok',
+        value: {
+          githubTotalStars: '50',
+          githubCommitsLastYear: '150',
+          githubContributedRepos: '10',
+          githubPrimaryLanguage: 'JavaScript',
+        },
       })
 
       const customContext = {
@@ -604,12 +613,12 @@ describe('ProfileChatter Integration Tests', () => {
 
       // Mock data sources (they shouldn't be called due to early validation failure)
       getWeatherData.mockResolvedValue({})
-      getGitHubData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({ status: 'ok', value: {} })
       getSpotifyData.mockResolvedValue({})
       getWakaTimeData.mockResolvedValue({})
       getTwitterData.mockResolvedValue({})
       getCodeStatsData.mockResolvedValue({})
-      getGitHubOAuthData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({ status: 'ok', value: {} })
 
       const customContext = {
         profile: { NAME: 'Test User' },

--- a/tests/integration/__tests__/ProfileChatter.integration.test.js
+++ b/tests/integration/__tests__/ProfileChatter.integration.test.js
@@ -4,42 +4,42 @@
  * Tests the overall flow from configuration to SVG generation with minimal mocking
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { generateChatSVG } from '../../../src/ProfileChatter.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { generateChatSVG } from '../../../src/ProfileChatter.js'
 
 // Mock all the data source functions (external API calls)
 vi.mock('../../../src/services/data_sources/weatherDataSource.js', () => ({
-  getWeatherData: vi.fn()
-}));
+  getWeatherData: vi.fn(),
+}))
 
 vi.mock('../../../src/services/data_sources/githubDataSource.js', () => ({
-  getGitHubData: vi.fn()
-}));
+  getGitHubData: vi.fn(),
+}))
 
 vi.mock('../../../src/services/data_sources/spotifyDataSource.js', () => ({
-  getSpotifyData: vi.fn()
-}));
+  getSpotifyData: vi.fn(),
+}))
 
 vi.mock('../../../src/services/data_sources/wakatimeDataSource.js', () => ({
-  getWakaTimeData: vi.fn()
-}));
+  getWakaTimeData: vi.fn(),
+}))
 
 vi.mock('../../../src/services/data_sources/twitterDataSource.js', () => ({
-  getTwitterData: vi.fn()
-}));
+  getTwitterData: vi.fn(),
+}))
 
 vi.mock('../../../src/services/data_sources/codestatsDataSource.js', () => ({
-  getCodeStatsData: vi.fn()
-}));
+  getCodeStatsData: vi.fn(),
+}))
 
 vi.mock('../../../src/services/data_sources/githubOAuthDataSource.js', () => ({
-  getGitHubOAuthData: vi.fn()
-}));
+  getGitHubOAuthData: vi.fn(),
+}))
 
 // Mock the config validator
 vi.mock('../../../src/utils/ConfigValidator.js', () => ({
-  validateConfiguration: vi.fn()
-}));
+  validateConfiguration: vi.fn(),
+}))
 
 // Mock DateTimeFormatService to return consistent values for testing
 vi.mock('../../../src/services/DateTimeFormatService.js', () => ({
@@ -57,17 +57,17 @@ vi.mock('../../../src/services/DateTimeFormatService.js', () => ({
       time24: '10:30',
       dateTime: 'May 23, 2025 at 10:30 AM',
       timezone: 'UTC',
-      timezoneAbbr: 'UTC'
+      timezoneAbbr: 'UTC',
     })),
-    formatWorkTenure: vi.fn(() => '18 years, 1 month and 7 days')
-  }
-}));
+    formatWorkTenure: vi.fn(() => '18 years, 1 month and 7 days'),
+  },
+}))
 
 // Mock the config with a minimal but complete configuration
 vi.mock('../../../src/config/config.js', () => ({
   config: {
     activeTheme: 'ios',
-    
+
     avatars: {
       enabled: true,
       me: { imageUrl: '', fallbackText: 'DJ' },
@@ -75,7 +75,7 @@ vi.mock('../../../src/config/config.js', () => ({
       sizePx: 32,
       shape: 'circle',
       xOffsetPx: 8,
-      yOffsetPx: 0
+      yOffsetPx: 0,
     },
 
     themes: {
@@ -87,8 +87,9 @@ vi.mock('../../../src/config/config.js', () => ({
         BACKGROUND_LIGHT: '#FFFFFF',
         BACKGROUND_DARK: '#000000',
         BUBBLE_RADIUS_PX: 18,
-        FONT_FAMILY: "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
-        
+        FONT_FAMILY:
+          "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+
         REACTION_FONT_SIZE_PX: 20,
         REACTION_BG_COLOR: '#F1F1F1',
         REACTION_BG_OPACITY: 0.9,
@@ -106,11 +107,14 @@ vi.mock('../../../src/config/config.js', () => ({
           VALUE_TEXT_INSIDE_COLOR: '#FFFFFF',
           BAR_HEIGHT_PX: 18,
           BAR_SPACING_PX: 10,
-          LABEL_FONT_FAMILY: "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+          LABEL_FONT_FAMILY:
+            "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
           LABEL_FONT_SIZE_PX: 13,
-          VALUE_TEXT_FONT_FAMILY: "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+          VALUE_TEXT_FONT_FAMILY:
+            "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
           VALUE_TEXT_FONT_SIZE_PX: 12,
-          TITLE_FONT_FAMILY: "'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+          TITLE_FONT_FAMILY:
+            "'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
           TITLE_FONT_SIZE_PX: 15,
           TITLE_LINE_HEIGHT_MULTIPLIER: 1.3,
           TITLE_BOTTOM_MARGIN_PX: 10,
@@ -120,7 +124,8 @@ vi.mock('../../../src/config/config.js', () => ({
           GRID_LINE_COLOR: '#F5F5F5',
           DONUT_STROKE_WIDTH_PX: 30,
           DONUT_CENTER_TEXT_FONT_SIZE_PX: 16,
-          DONUT_CENTER_TEXT_FONT_FAMILY: "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+          DONUT_CENTER_TEXT_FONT_FAMILY:
+            "'SF Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
           ME_DONUT_CENTER_TEXT_COLOR: '#FFFFFF',
           VISITOR_DONUT_CENTER_TEXT_COLOR: '#000000',
           ME_DONUT_LEGEND_TEXT_COLOR: '#FFFFFF',
@@ -130,17 +135,17 @@ vi.mock('../../../src/config/config.js', () => ({
           DONUT_LEGEND_MARKER_SIZE_PX: 10,
           DONUT_ANIMATION_DURATION_SEC: 1.0,
           DONUT_SEGMENT_ANIMATION_DELAY_SEC: 0.2,
-          
+
           ME_TITLE_COLOR: '#FFFFFF',
           ME_LABEL_COLOR: '#E2F0FF',
           ME_VALUE_TEXT_COLOR: '#FFFFFF',
-          
+
           VISITOR_TITLE_COLOR: '#000000',
           VISITOR_LABEL_COLOR: '#444444',
-          VISITOR_VALUE_TEXT_COLOR: '#000000'
-        }
+          VISITOR_VALUE_TEXT_COLOR: '#000000',
+        },
       },
-      
+
       android: {
         ME_BUBBLE_COLOR: '#D1E6FF',
         VISITOR_BUBBLE_COLOR: '#F0F0F0',
@@ -150,7 +155,7 @@ vi.mock('../../../src/config/config.js', () => ({
         BACKGROUND_DARK: '#121212',
         BUBBLE_RADIUS_PX: 8,
         FONT_FAMILY: "'Roboto', sans-serif",
-        
+
         REACTION_FONT_SIZE_PX: 14,
         REACTION_BG_COLOR: '#E8E8E8',
         REACTION_BG_OPACITY: 1.0,
@@ -199,9 +204,9 @@ vi.mock('../../../src/config/config.js', () => ({
 
           VISITOR_TITLE_COLOR: '#212121',
           VISITOR_LABEL_COLOR: '#616161',
-          VISITOR_VALUE_TEXT_COLOR: '#212121'
-        }
-      }
+          VISITOR_VALUE_TEXT_COLOR: '#212121',
+        },
+      },
     },
 
     profile: {
@@ -215,7 +220,7 @@ vi.mock('../../../src/config/config.js', () => ({
       WAKATIME_USERNAME: 'testuser',
       TWITTER_USERNAME: 'testuser',
       CODESTATS_USERNAME: 'testuser',
-      TIMEZONE: 'UTC'
+      TIMEZONE: 'UTC',
     },
 
     cache: {
@@ -224,7 +229,7 @@ vi.mock('../../../src/config/config.js', () => ({
       GITHUB_OAUTH_CACHE_TTL_MS: 3600000,
       TWITTER_CACHE_TTL_MS: 3600000,
       CODESTATS_CACHE_TTL_MS: 7200000,
-      SPOTIFY_CACHE_TTL_MS: 900000
+      SPOTIFY_CACHE_TTL_MS: 900000,
     },
 
     apiDefaults: {
@@ -239,7 +244,7 @@ vi.mock('../../../src/config/config.js', () => ({
       GITHUB_PRIMARY_LANGUAGE: 'None',
       TWITTER_FOLLOWERS: '120',
       CODESTATS_XP: '0',
-      SPOTIFY_NOW_PLAYING: 'Not currently listening to music.'
+      SPOTIFY_NOW_PLAYING: 'Not currently listening to music.',
     },
 
     layout: {
@@ -268,7 +273,7 @@ vi.mock('../../../src/config/config.js', () => ({
         ANIMATION_DELAY_SEC: 0.2,
         FADE_IN_DURATION_SEC: 0.3,
         READ_DELAY_SEC: 1.5,
-        READ_TRANSITION_SEC: 0.2
+        READ_TRANSITION_SEC: 0.2,
       },
 
       VISIBLE_MESSAGES: 6,
@@ -283,7 +288,7 @@ vi.mock('../../../src/config/config.js', () => ({
         SENDER_CHANGE_DELAY_MS: 1800,
         MESSAGE_VERTICAL_SPACING: 32,
         BOTTOM_MARGIN: 40,
-        ANIMATION_END_BUFFER_MS: 2000
+        ANIMATION_END_BUFFER_MS: 2000,
       },
 
       ANIMATION: {
@@ -310,8 +315,8 @@ vi.mock('../../../src/config/config.js', () => ({
         SCROLL_DELAY_BUFFER_SEC: 2.2,
         MIN_SCROLL_DURATION_SEC: 1.2,
         SCROLL_PIXELS_PER_SEC: 18,
-        SCROLL_SPEED_MULTIPLIER: 1.0
-      }
+        SCROLL_SPEED_MULTIPLIER: 1.0,
+      },
     },
 
     wakatime: {
@@ -320,228 +325,250 @@ vi.mock('../../../src/config/config.js', () => ({
         wakatime_summary: 'No coding activity data available',
         wakatime_top_language: 'N/A',
         wakatime_top_language_percent: '0',
-        wakatime_chart_data: []
+        wakatime_chart_data: [],
       },
-      cacheTtlMs: 7200000
-    }
-  }
-}));
+      cacheTtlMs: 7200000,
+    },
+  },
+}))
 
 // Import mocked modules to access their mock functions
-import { getWeatherData } from '../../../src/services/data_sources/weatherDataSource.js';
-import { getGitHubData } from '../../../src/services/data_sources/githubDataSource.js';
-import { getSpotifyData } from '../../../src/services/data_sources/spotifyDataSource.js';
-import { getWakaTimeData } from '../../../src/services/data_sources/wakatimeDataSource.js';
-import { getTwitterData } from '../../../src/services/data_sources/twitterDataSource.js';
-import { getCodeStatsData } from '../../../src/services/data_sources/codestatsDataSource.js';
-import { getGitHubOAuthData } from '../../../src/services/data_sources/githubOAuthDataSource.js';
-import { validateConfiguration } from '../../../src/utils/ConfigValidator.js';
+import { getWeatherData } from '../../../src/services/data_sources/weatherDataSource.js'
+import { getGitHubData } from '../../../src/services/data_sources/githubDataSource.js'
+import { getSpotifyData } from '../../../src/services/data_sources/spotifyDataSource.js'
+import { getWakaTimeData } from '../../../src/services/data_sources/wakatimeDataSource.js'
+import { getTwitterData } from '../../../src/services/data_sources/twitterDataSource.js'
+import { getCodeStatsData } from '../../../src/services/data_sources/codestatsDataSource.js'
+import { getGitHubOAuthData } from '../../../src/services/data_sources/githubOAuthDataSource.js'
+import { validateConfiguration } from '../../../src/utils/ConfigValidator.js'
 
 // Mock console methods to check for expected logging
-let consoleMocks;
+let consoleMocks
 
 describe('ProfileChatter Integration Tests', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    
+    vi.clearAllMocks()
+
     // Set up console mocks
     consoleMocks = {
       error: vi.spyOn(console, 'error').mockImplementation(() => {}),
       warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
       log: vi.spyOn(console, 'log').mockImplementation(() => {}),
-      info: vi.spyOn(console, 'info').mockImplementation(() => {})
-    };
-  });
+      info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+    }
+  })
 
   afterEach(() => {
     // Restore console methods
-    consoleMocks.error.mockRestore();
-    consoleMocks.warn.mockRestore();
-    consoleMocks.log.mockRestore();
-    consoleMocks.info.mockRestore();
-    
-    vi.restoreAllMocks();
-  });
+    consoleMocks.error.mockRestore()
+    consoleMocks.warn.mockRestore()
+    consoleMocks.log.mockRestore()
+    consoleMocks.info.mockRestore()
+
+    vi.restoreAllMocks()
+  })
 
   describe('generateChatSVG()', () => {
     it('Scenario 1: Successful End-to-End Flow with Basic customContext', async () => {
       // Arrange
-      validateConfiguration.mockReturnValue(true);
-      
+      validateConfiguration.mockReturnValue(true)
+
       // Mock all data source functions to return their default values
       getWeatherData.mockResolvedValue({
         temperature: '72°F (22°C)',
         weatherDescription: 'partly cloudy',
-        emoji: '⛅'
-      });
-      
+        emoji: '⛅',
+      })
+
       getGitHubData.mockResolvedValue({
         githubPublicRepos: '12',
-        githubFollowers: '48'
-      });
-      
+        githubFollowers: '48',
+      })
+
       getSpotifyData.mockResolvedValue({
-        spotifyTrack: 'Not currently listening to music.'
-      });
-      
+        spotifyTrack: 'Not currently listening to music.',
+      })
+
       getWakaTimeData.mockResolvedValue({
         wakatime_summary: 'No coding activity data available',
         wakatime_top_language: 'N/A',
-        wakatime_top_language_percent: '0'
-      });
-      
+        wakatime_top_language_percent: '0',
+      })
+
       getTwitterData.mockResolvedValue({
-        twitterFollowers: '120'
-      });
-      
+        twitterFollowers: '120',
+      })
+
       getCodeStatsData.mockResolvedValue({
-        codestatsXP: '0'
-      });
-      
+        codestatsXP: '0',
+      })
+
       getGitHubOAuthData.mockResolvedValue({
         githubTotalStars: '0',
         githubCommitsLastYear: '0',
         githubContributedRepos: '0',
-        githubPrimaryLanguage: 'None'
-      });
+        githubPrimaryLanguage: 'None',
+      })
 
       const customContext = {
         profile: { NAME: 'John Doe' },
         activeTheme: 'ios',
         chatMessages: [
           { id: '1', sender: 'me', text: 'Hello {name}!' },
-          { id: '2', sender: 'visitor', text: 'Hi there! How are you?' }
-        ]
-      };
+          { id: '2', sender: 'visitor', text: 'Hi there! How are you?' },
+        ],
+      }
 
       // Act
-      const result = await generateChatSVG(customContext);
+      const result = await generateChatSVG(customContext)
 
       // Assert
-      expect(result).toBeDefined();
-      expect(typeof result).toBe('string');
-      expect(result.startsWith('<svg')).toBe(true);
-      expect(result.endsWith('</svg>')).toBe(true);
-      expect(result).toContain('John Doe'); // Profile name should be in the SVG
-      expect(result).toContain('Hello John Doe!'); // Chat message with placeholder replacement
-      expect(result).toContain('#0B93F6'); // iOS theme color should be present
-      expect(consoleMocks.error).not.toHaveBeenCalledWith(expect.stringMatching(/Error generating SVG/));
-    });
+      expect(result).toBeDefined()
+      expect(typeof result).toBe('string')
+      expect(result.startsWith('<svg')).toBe(true)
+      expect(result.endsWith('</svg>')).toBe(true)
+      expect(result).toContain('John Doe') // Profile name should be in the SVG
+      expect(result).toContain('Hello John Doe!') // Chat message with placeholder replacement
+      expect(result).toContain('#0B93F6') // iOS theme color should be present
+      expect(consoleMocks.error).not.toHaveBeenCalledWith(
+        expect.stringMatching(/Error generating SVG/)
+      )
+    })
 
     it('Scenario 2: Flow with Specific Mocked API Data & All Placeholders Used', async () => {
       // Arrange
-      validateConfiguration.mockReturnValue(true);
-      
+      validateConfiguration.mockReturnValue(true)
+
       // Mock each data source function to return specific, non-default data
       getWeatherData.mockResolvedValue({
         temperature: '75F Test',
         weatherDescription: 'testing clouds',
-        emoji: '🧪'
-      });
-      
+        emoji: '🧪',
+      })
+
       getGitHubData.mockResolvedValue({
         githubPublicRepos: '25',
-        githubFollowers: '150'
-      });
-      
+        githubFollowers: '150',
+      })
+
       getSpotifyData.mockResolvedValue({
-        spotifyTrack: 'Test Song by Test Artist'
-      });
-      
+        spotifyTrack: 'Test Song by Test Artist',
+      })
+
       getWakaTimeData.mockResolvedValue({
         wakatime_summary: 'Coded for 40 hrs in the last week',
         wakatime_top_language: 'JavaScript',
-        wakatime_top_language_percent: '65'
-      });
-      
+        wakatime_top_language_percent: '65',
+      })
+
       getTwitterData.mockResolvedValue({
-        twitterFollowers: '500'
-      });
-      
+        twitterFollowers: '500',
+      })
+
       getCodeStatsData.mockResolvedValue({
-        codestatsXP: '15000'
-      });
-      
+        codestatsXP: '15000',
+      })
+
       getGitHubOAuthData.mockResolvedValue({
         githubTotalStars: '100',
         githubCommitsLastYear: '250',
         githubContributedRepos: '15',
-        githubPrimaryLanguage: 'TypeScript'
-      });
+        githubPrimaryLanguage: 'TypeScript',
+      })
 
       const customContext = {
         profile: { NAME: 'Jane Developer' },
         activeTheme: 'android',
         chatMessages: [
-          { id: '1', sender: 'me', text: 'Weather is {temperature} with {weatherDescription} {emoji}' },
-          { id: '2', sender: 'visitor', text: 'I have {githubPublicRepos} repos and {githubFollowers} followers' },
+          {
+            id: '1',
+            sender: 'me',
+            text: 'Weather is {temperature} with {weatherDescription} {emoji}',
+          },
+          {
+            id: '2',
+            sender: 'visitor',
+            text: 'I have {githubPublicRepos} repos and {githubFollowers} followers',
+          },
           { id: '3', sender: 'me', text: 'Currently listening to: {spotifyTrack}' },
-          { id: '4', sender: 'visitor', text: 'My top language is {wakatime_top_language} at {wakatime_top_language_percent}%' },
-          { id: '5', sender: 'me', text: 'Follow me on Twitter! I have {twitterFollowers} followers' },
+          {
+            id: '4',
+            sender: 'visitor',
+            text: 'My top language is {wakatime_top_language} at {wakatime_top_language_percent}%',
+          },
+          {
+            id: '5',
+            sender: 'me',
+            text: 'Follow me on Twitter! I have {twitterFollowers} followers',
+          },
           { id: '6', sender: 'visitor', text: 'Code::Stats XP: {codestatsXP}' },
-          { id: '7', sender: 'me', text: 'GitHub stats: {githubTotalStars} stars, {githubCommitsLastYear} commits' }
-        ]
-      };
+          {
+            id: '7',
+            sender: 'me',
+            text: 'GitHub stats: {githubTotalStars} stars, {githubCommitsLastYear} commits',
+          },
+        ],
+      }
 
       // Act
-      const result = await generateChatSVG(customContext);
+      const result = await generateChatSVG(customContext)
 
       // Assert
-      expect(result).toBeDefined();
-      expect(result).toContain('75F Test'); // Specific weather temperature
-      expect(result).toContain('testing clouds'); // Specific weather description
-      expect(result).toContain('🧪'); // Specific weather emoji
-      expect(result).toContain('25'); // Specific GitHub repos
-      expect(result).toContain('150'); // Specific GitHub followers
+      expect(result).toBeDefined()
+      expect(result).toContain('75F Test') // Specific weather temperature
+      expect(result).toContain('testing clouds') // Specific weather description
+      expect(result).toContain('🧪') // Specific weather emoji
+      expect(result).toContain('25') // Specific GitHub repos
+      expect(result).toContain('150') // Specific GitHub followers
       // Check for Spotify track (may be wrapped across lines)
-      expect(result).toContain('Test Song by Test'); // Specific Spotify track (partial match due to wrapping)
-      expect(result).toContain('Artist'); // Second part of Spotify track
-      expect(result).toContain('JavaScript'); // Specific WakaTime language
-      expect(result).toContain('65%'); // Specific WakaTime percentage
-      expect(result).toContain('500'); // Specific Twitter followers
-      expect(result).toContain('15000'); // Specific Code::Stats XP
-      expect(result).toContain('100'); // Specific GitHub stars
-      expect(result).toContain('250'); // Specific GitHub commits
-      expect(result).toContain('#D1E6FF'); // Android theme color should be present
-    });
+      expect(result).toContain('Test Song by Test') // Specific Spotify track (partial match due to wrapping)
+      expect(result).toContain('Artist') // Second part of Spotify track
+      expect(result).toContain('JavaScript') // Specific WakaTime language
+      expect(result).toContain('65%') // Specific WakaTime percentage
+      expect(result).toContain('500') // Specific Twitter followers
+      expect(result).toContain('15000') // Specific Code::Stats XP
+      expect(result).toContain('100') // Specific GitHub stars
+      expect(result).toContain('250') // Specific GitHub commits
+      expect(result).toContain('#D1E6FF') // Android theme color should be present
+    })
 
     it('Scenario 3: One Data Source Fails, All Fall Back to Defaults', async () => {
       // Arrange
-      validateConfiguration.mockReturnValue(true);
-      
+      validateConfiguration.mockReturnValue(true)
+
       // Mock getWeatherData to reject with an error
-      getWeatherData.mockRejectedValue(new Error('Weather API failed'));
-      
+      getWeatherData.mockRejectedValue(new Error('Weather API failed'))
+
       // Mock other data sources to succeed with sample data
       getGitHubData.mockResolvedValue({
         githubPublicRepos: '20',
-        githubFollowers: '100'
-      });
-      
+        githubFollowers: '100',
+      })
+
       getSpotifyData.mockResolvedValue({
-        spotifyTrack: 'Working Song by Developer'
-      });
-      
+        spotifyTrack: 'Working Song by Developer',
+      })
+
       getWakaTimeData.mockResolvedValue({
         wakatime_summary: 'Coded for 30 hrs in the last week',
         wakatime_top_language: 'Python',
-        wakatime_top_language_percent: '50'
-      });
-      
+        wakatime_top_language_percent: '50',
+      })
+
       getTwitterData.mockResolvedValue({
-        twitterFollowers: '200'
-      });
-      
+        twitterFollowers: '200',
+      })
+
       getCodeStatsData.mockResolvedValue({
-        codestatsXP: '8000'
-      });
-      
+        codestatsXP: '8000',
+      })
+
       getGitHubOAuthData.mockResolvedValue({
         githubTotalStars: '50',
         githubCommitsLastYear: '150',
         githubContributedRepos: '10',
-        githubPrimaryLanguage: 'JavaScript'
-      });
+        githubPrimaryLanguage: 'JavaScript',
+      })
 
       const customContext = {
         profile: { NAME: 'Test User' },
@@ -549,73 +576,71 @@ describe('ProfileChatter Integration Tests', () => {
         chatMessages: [
           { id: '1', sender: 'me', text: 'Weather: {temperature} {weatherDescription}' },
           { id: '2', sender: 'visitor', text: 'GitHub: {githubPublicRepos} repos' },
-          { id: '3', sender: 'me', text: 'Music: {spotifyTrack}' }
-        ]
-      };
+          { id: '3', sender: 'me', text: 'Music: {spotifyTrack}' },
+        ],
+      }
 
       // Act
-      const result = await generateChatSVG(customContext);
+      const result = await generateChatSVG(customContext)
 
       // Assert
-      expect(result).toBeDefined();
-      expect(result.startsWith('<svg')).toBe(true);
-      expect(result.endsWith('</svg>')).toBe(true);
-      
+      expect(result).toBeDefined()
+      expect(result.startsWith('<svg')).toBe(true)
+      expect(result.endsWith('</svg>')).toBe(true)
+
       // When one API fails, DataService.getDynamicData() catches the error and uses defaults for all
-      expect(result).toContain('72°F (22°C)'); // Default temperature
-      expect(result).toContain('partly cloudy'); // Default weather description
-      expect(result).toContain('12'); // Default GitHub repos (not the mocked 20)
-      expect(result).toContain('listening to music'); // Default Spotify text (partial match due to line wrapping)
-      
+      expect(result).toContain('72°F (22°C)') // Default temperature
+      expect(result).toContain('partly cloudy') // Default weather description
+      expect(result).toContain('12') // Default GitHub repos (not the mocked 20)
+      expect(result).toContain('listening to music') // Default Spotify text (partial match due to line wrapping)
+
       // Should have logged an error about fetching APIs, but SVG generation should still succeed
-      expect(consoleMocks.error).toHaveBeenCalledWith('Error fetching APIs:', 'Weather API failed');
-    });
+      expect(consoleMocks.error).toHaveBeenCalledWith('Error fetching APIs:', 'Weather API failed')
+    })
 
     it('Scenario 4: validateConfiguration returns false', async () => {
       // Arrange
-      validateConfiguration.mockReturnValue(false);
-      
+      validateConfiguration.mockReturnValue(false)
+
       // Mock data sources (they shouldn't be called due to early validation failure)
-      getWeatherData.mockResolvedValue({});
-      getGitHubData.mockResolvedValue({});
-      getSpotifyData.mockResolvedValue({});
-      getWakaTimeData.mockResolvedValue({});
-      getTwitterData.mockResolvedValue({});
-      getCodeStatsData.mockResolvedValue({});
-      getGitHubOAuthData.mockResolvedValue({});
+      getWeatherData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({})
+      getSpotifyData.mockResolvedValue({})
+      getWakaTimeData.mockResolvedValue({})
+      getTwitterData.mockResolvedValue({})
+      getCodeStatsData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({})
 
       const customContext = {
         profile: { NAME: 'Test User' },
         activeTheme: 'ios',
-        chatMessages: [
-          { id: '1', sender: 'me', text: 'This should not be rendered' }
-        ]
-      };
+        chatMessages: [{ id: '1', sender: 'me', text: 'This should not be rendered' }],
+      }
 
       // Act
-      const result = await generateChatSVG(customContext);
+      const result = await generateChatSVG(customContext)
 
       // Assert
-      expect(result).toBeDefined();
-      expect(result).toContain('Configuration Error!');
-      expect(result).toContain('Please check console logs');
-      expect(result).toContain('for details.');
-      expect(result.startsWith('<svg')).toBe(true);
-      expect(result.endsWith('</svg>')).toBe(true);
-      
+      expect(result).toBeDefined()
+      expect(result).toContain('Configuration Error!')
+      expect(result).toContain('Please check console logs')
+      expect(result).toContain('for details.')
+      expect(result.startsWith('<svg')).toBe(true)
+      expect(result.endsWith('</svg>')).toBe(true)
+
       // Should have logged configuration error
       expect(consoleMocks.error).toHaveBeenCalledWith(
         expect.stringContaining('Critical configuration errors found')
-      );
-      
+      )
+
       // Data source functions should not have been called
-      expect(getWeatherData).not.toHaveBeenCalled();
-      expect(getGitHubData).not.toHaveBeenCalled();
-      expect(getSpotifyData).not.toHaveBeenCalled();
-      expect(getWakaTimeData).not.toHaveBeenCalled();
-      expect(getTwitterData).not.toHaveBeenCalled();
-      expect(getCodeStatsData).not.toHaveBeenCalled();
-      expect(getGitHubOAuthData).not.toHaveBeenCalled();
-    });
-  });
-});
+      expect(getWeatherData).not.toHaveBeenCalled()
+      expect(getGitHubData).not.toHaveBeenCalled()
+      expect(getSpotifyData).not.toHaveBeenCalled()
+      expect(getWakaTimeData).not.toHaveBeenCalled()
+      expect(getTwitterData).not.toHaveBeenCalled()
+      expect(getCodeStatsData).not.toHaveBeenCalled()
+      expect(getGitHubOAuthData).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/services/__tests__/DataService.test.js
+++ b/tests/unit/services/__tests__/DataService.test.js
@@ -138,8 +138,8 @@ describe('DataService', () => {
       })
 
       getGitHubData.mockResolvedValue({
-        githubPublicRepos: '15',
-        githubFollowers: '25',
+        status: 'ok',
+        value: { githubPublicRepos: '15', githubFollowers: '25' },
       })
 
       getWakaTimeData.mockResolvedValue({
@@ -161,10 +161,13 @@ describe('DataService', () => {
       })
 
       getGitHubOAuthData.mockResolvedValue({
-        githubTotalStars: '50',
-        githubCommitsLastYear: '300',
-        githubContributedRepos: '8',
-        githubPrimaryLanguage: 'TypeScript',
+        status: 'ok',
+        value: {
+          githubTotalStars: '50',
+          githubCommitsLastYear: '300',
+          githubContributedRepos: '8',
+          githubPrimaryLanguage: 'TypeScript',
+        },
       })
 
       const result = await DataService.getDynamicData()
@@ -194,6 +197,33 @@ describe('DataService', () => {
       expect(DateTimeFormatServiceInstance.formatWorkTenure).toHaveBeenCalled()
     })
 
+    it('records per-source status so a fallback is distinguishable from live data', async () => {
+      getWeatherData.mockResolvedValue({})
+      getWakaTimeData.mockResolvedValue({})
+      getTwitterData.mockResolvedValue({})
+      getCodeStatsData.mockResolvedValue({})
+      getSpotifyData.mockResolvedValue({})
+      // github fell back to defaults; githubOAuth is live
+      getGitHubData.mockResolvedValue({
+        status: 'fallback',
+        value: { githubPublicRepos: '10', githubFollowers: '5' },
+        error: { message: 'rate limited', status: 403 },
+        fetchedAt: 123,
+      })
+      getGitHubOAuthData.mockResolvedValue({
+        status: 'ok',
+        value: { githubTotalStars: '7' },
+        fetchedAt: 456,
+      })
+
+      await DataService.getDynamicData()
+
+      const bySource = Object.fromEntries(DataService.lastSourceStatuses.map((s) => [s.source, s]))
+      expect(bySource.github.status).toBe('fallback')
+      expect(bySource.github.error.status).toBe(403)
+      expect(bySource.githubOAuth.status).toBe('ok')
+    })
+
     it('should handle API failures gracefully', async () => {
       // Mock all APIs to fail to test error handling
       getWeatherData.mockRejectedValue(new Error('Weather API failed'))
@@ -218,12 +248,12 @@ describe('DataService', () => {
     it('should handle custom profile data overrides', async () => {
       // Mock all APIs to return empty data
       getWeatherData.mockResolvedValue({})
-      getGitHubData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({ status: 'ok', value: {} })
       getWakaTimeData.mockResolvedValue({})
       getTwitterData.mockResolvedValue({})
       getCodeStatsData.mockResolvedValue({})
       getSpotifyData.mockResolvedValue({})
-      getGitHubOAuthData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({ status: 'ok', value: {} })
 
       const customData = {
         profile: {
@@ -258,12 +288,12 @@ describe('DataService', () => {
     it('should handle WORK_START_DATE as Date object', async () => {
       // Mock all APIs
       getWeatherData.mockResolvedValue({})
-      getGitHubData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({ status: 'ok', value: {} })
       getWakaTimeData.mockResolvedValue({})
       getTwitterData.mockResolvedValue({})
       getCodeStatsData.mockResolvedValue({})
       getSpotifyData.mockResolvedValue({})
-      getGitHubOAuthData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({ status: 'ok', value: {} })
 
       const customWorkStartDate = new Date('2022-03-10T00:00:00.000Z')
       const customData = {
@@ -283,12 +313,12 @@ describe('DataService', () => {
     it('should handle customData.workStartDate directly', async () => {
       // Mock all APIs
       getWeatherData.mockResolvedValue({})
-      getGitHubData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({ status: 'ok', value: {} })
       getWakaTimeData.mockResolvedValue({})
       getTwitterData.mockResolvedValue({})
       getCodeStatsData.mockResolvedValue({})
       getSpotifyData.mockResolvedValue({})
-      getGitHubOAuthData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({ status: 'ok', value: {} })
 
       const customWorkStartDate = new Date('2021-08-01T00:00:00.000Z')
       const customData = {
@@ -306,12 +336,12 @@ describe('DataService', () => {
     it('should fallback to UTC on timezone formatting error', async () => {
       // Mock all APIs
       getWeatherData.mockResolvedValue({})
-      getGitHubData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({ status: 'ok', value: {} })
       getWakaTimeData.mockResolvedValue({})
       getTwitterData.mockResolvedValue({})
       getCodeStatsData.mockResolvedValue({})
       getSpotifyData.mockResolvedValue({})
-      getGitHubOAuthData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({ status: 'ok', value: {} })
 
       // Mock DateTimeFormatService to throw error first, then succeed
       DateTimeFormatServiceInstance.formatCurrentDateTime
@@ -362,12 +392,12 @@ describe('DataService', () => {
     it('should preserve additional customData properties', async () => {
       // Mock all APIs
       getWeatherData.mockResolvedValue({})
-      getGitHubData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({ status: 'ok', value: {} })
       getWakaTimeData.mockResolvedValue({})
       getTwitterData.mockResolvedValue({})
       getCodeStatsData.mockResolvedValue({})
       getSpotifyData.mockResolvedValue({})
-      getGitHubOAuthData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({ status: 'ok', value: {} })
 
       const customData = {
         customProperty: 'custom value',

--- a/tests/unit/services/__tests__/DataService.test.js
+++ b/tests/unit/services/__tests__/DataService.test.js
@@ -2,44 +2,44 @@
  * Unit tests for DataService.js
  * Tests data orchestration with extensive mocking of dependencies
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Mock all data source modules BEFORE importing DataService
 vi.mock('../../../../src/services/data_sources/weatherDataSource.js', () => ({
-  getWeatherData: vi.fn()
-}));
+  getWeatherData: vi.fn(),
+}))
 
 vi.mock('../../../../src/services/data_sources/githubDataSource.js', () => ({
-  getGitHubData: vi.fn()
-}));
+  getGitHubData: vi.fn(),
+}))
 
 vi.mock('../../../../src/services/data_sources/wakatimeDataSource.js', () => ({
-  getWakaTimeData: vi.fn()
-}));
+  getWakaTimeData: vi.fn(),
+}))
 
 vi.mock('../../../../src/services/data_sources/twitterDataSource.js', () => ({
-  getTwitterData: vi.fn()
-}));
+  getTwitterData: vi.fn(),
+}))
 
 vi.mock('../../../../src/services/data_sources/codestatsDataSource.js', () => ({
-  getCodeStatsData: vi.fn()
-}));
+  getCodeStatsData: vi.fn(),
+}))
 
 vi.mock('../../../../src/services/data_sources/spotifyDataSource.js', () => ({
-  getSpotifyData: vi.fn()
-}));
+  getSpotifyData: vi.fn(),
+}))
 
 vi.mock('../../../../src/services/data_sources/githubOAuthDataSource.js', () => ({
-  getGitHubOAuthData: vi.fn()
-}));
+  getGitHubOAuthData: vi.fn(),
+}))
 
 // Mock DateTimeFormatService
 vi.mock('../../../../src/services/DateTimeFormatService.js', () => ({
   default: {
     formatCurrentDateTime: vi.fn(),
-    formatWorkTenure: vi.fn()
-  }
-}));
+    formatWorkTenure: vi.fn(),
+  },
+}))
 
 // Mock config
 vi.mock('../../../../src/config/config.js', () => ({
@@ -51,7 +51,7 @@ vi.mock('../../../../src/config/config.js', () => ({
       COMPANY: 'Test Company',
       CURRENT_PROJECT: 'Test Project',
       TIMEZONE: 'UTC',
-      WORK_START_DATE: new Date('2020-01-01T00:00:00.000Z')
+      WORK_START_DATE: new Date('2020-01-01T00:00:00.000Z'),
     },
     apiDefaults: {
       TEMPERATURE: '70°F',
@@ -65,46 +65,46 @@ vi.mock('../../../../src/config/config.js', () => ({
       GITHUB_PRIMARY_LANGUAGE: 'JavaScript',
       TWITTER_FOLLOWERS: '100',
       CODESTATS_XP: '1000',
-      SPOTIFY_NOW_PLAYING: 'Not listening'
+      SPOTIFY_NOW_PLAYING: 'Not listening',
     },
     wakatime: {
       defaults: {
         wakatime_summary: 'No data',
         wakatime_top_language: 'None',
-        wakatime_top_language_percent: '0'
-      }
-    }
-  }
-}));
+        wakatime_top_language_percent: '0',
+      },
+    },
+  },
+}))
 
 // Import after mocks are set up
-import DataService from '../../../../src/services/DataService.js';
-import { getWeatherData } from '../../../../src/services/data_sources/weatherDataSource.js';
-import { getGitHubData } from '../../../../src/services/data_sources/githubDataSource.js';
-import { getWakaTimeData } from '../../../../src/services/data_sources/wakatimeDataSource.js';
-import { getTwitterData } from '../../../../src/services/data_sources/twitterDataSource.js';
-import { getCodeStatsData } from '../../../../src/services/data_sources/codestatsDataSource.js';
-import { getSpotifyData } from '../../../../src/services/data_sources/spotifyDataSource.js';
-import { getGitHubOAuthData } from '../../../../src/services/data_sources/githubOAuthDataSource.js';
-import DateTimeFormatServiceInstance from '../../../../src/services/DateTimeFormatService.js';
+import DataService from '../../../../src/services/DataService.js'
+import { getWeatherData } from '../../../../src/services/data_sources/weatherDataSource.js'
+import { getGitHubData } from '../../../../src/services/data_sources/githubDataSource.js'
+import { getWakaTimeData } from '../../../../src/services/data_sources/wakatimeDataSource.js'
+import { getTwitterData } from '../../../../src/services/data_sources/twitterDataSource.js'
+import { getCodeStatsData } from '../../../../src/services/data_sources/codestatsDataSource.js'
+import { getSpotifyData } from '../../../../src/services/data_sources/spotifyDataSource.js'
+import { getGitHubOAuthData } from '../../../../src/services/data_sources/githubOAuthDataSource.js'
+import DateTimeFormatServiceInstance from '../../../../src/services/DateTimeFormatService.js'
 
 describe('DataService', () => {
-  let consoleErrorSpy;
-  let consoleInfoSpy;
-  let consoleWarnSpy;
+  let consoleErrorSpy
+  let consoleInfoSpy
+  let consoleWarnSpy
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-  });
+    vi.clearAllMocks()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
 
   afterEach(() => {
-    consoleErrorSpy.mockRestore();
-    consoleInfoSpy.mockRestore();
-    consoleWarnSpy.mockRestore();
-  });
+    consoleErrorSpy.mockRestore()
+    consoleInfoSpy.mockRestore()
+    consoleWarnSpy.mockRestore()
+  })
 
   describe('getDynamicData', () => {
     const mockDateTimeData = {
@@ -120,113 +120,110 @@ describe('DataService', () => {
       time24: '14:30',
       dateTime: 'June 5, 2023 at 2:30 PM',
       timezone: 'UTC',
-      timezoneAbbr: 'UTC'
-    };
+      timezoneAbbr: 'UTC',
+    }
 
     beforeEach(() => {
       // Set up default DateTimeFormatService mocks
-      DateTimeFormatServiceInstance.formatCurrentDateTime.mockReturnValue(mockDateTimeData);
-      DateTimeFormatServiceInstance.formatWorkTenure.mockReturnValue('3 years and 5 months');
-    });
+      DateTimeFormatServiceInstance.formatCurrentDateTime.mockReturnValue(mockDateTimeData)
+      DateTimeFormatServiceInstance.formatWorkTenure.mockReturnValue('3 years and 5 months')
+    })
 
     it('should successfully merge data from all API sources', async () => {
       // Mock all data sources to return success data
       getWeatherData.mockResolvedValue({
         temperature: '75°F (24°C)',
         weatherDescription: 'partly cloudy',
-        emoji: '⛅'
-      });
+        emoji: '⛅',
+      })
 
       getGitHubData.mockResolvedValue({
         githubPublicRepos: '15',
-        githubFollowers: '25'
-      });
+        githubFollowers: '25',
+      })
 
       getWakaTimeData.mockResolvedValue({
         wakatime_summary: 'Coded for 8 hrs',
         wakatime_top_language: 'JavaScript',
-        wakatime_top_language_percent: '65'
-      });
+        wakatime_top_language_percent: '65',
+      })
 
       getTwitterData.mockResolvedValue({
-        twitterFollowers: '150'
-      });
+        twitterFollowers: '150',
+      })
 
       getCodeStatsData.mockResolvedValue({
-        codestatsXP: '2500'
-      });
+        codestatsXP: '2500',
+      })
 
       getSpotifyData.mockResolvedValue({
-        spotifyTrack: 'Test Song by Test Artist'
-      });
+        spotifyTrack: 'Test Song by Test Artist',
+      })
 
       getGitHubOAuthData.mockResolvedValue({
         githubTotalStars: '50',
         githubCommitsLastYear: '300',
         githubContributedRepos: '8',
-        githubPrimaryLanguage: 'TypeScript'
-      });
+        githubPrimaryLanguage: 'TypeScript',
+      })
 
-      const result = await DataService.getDynamicData();
+      const result = await DataService.getDynamicData()
 
       // Verify all date/time data is included
-      expect(result.currentDayOfWeek).toBe('Monday');
-      expect(result.dayName).toBe('Monday');
-      expect(result.time).toBe('2:30 PM');
-      expect(result.timezone).toBe('UTC');
+      expect(result.currentDayOfWeek).toBe('Monday')
+      expect(result.dayName).toBe('Monday')
+      expect(result.time).toBe('2:30 PM')
+      expect(result.timezone).toBe('UTC')
 
       // Verify API data is merged
-      expect(result.temperature).toBe('75°F (24°C)');
-      expect(result.githubPublicRepos).toBe('15');
-      expect(result.wakatime_summary).toBe('Coded for 8 hrs');
-      expect(result.twitterFollowers).toBe('100');
-      expect(result.codestatsXP).toBe('2500');
-      expect(result.spotifyTrack).toBe('Test Song by Test Artist');
-      expect(result.githubTotalStars).toBe('50');
+      expect(result.temperature).toBe('75°F (24°C)')
+      expect(result.githubPublicRepos).toBe('15')
+      expect(result.wakatime_summary).toBe('Coded for 8 hrs')
+      expect(result.twitterFollowers).toBe('100')
+      expect(result.codestatsXP).toBe('2500')
+      expect(result.spotifyTrack).toBe('Test Song by Test Artist')
+      expect(result.githubTotalStars).toBe('50')
 
       // Verify profile data from config
-      expect(result.name).toBe('Test User');
-      expect(result.profession).toBe('Developer');
-      expect(result.workTenure).toBe('3 years and 5 months');
+      expect(result.name).toBe('Test User')
+      expect(result.profession).toBe('Developer')
+      expect(result.workTenure).toBe('3 years and 5 months')
 
       // Verify DateTimeFormatService was called correctly
-      expect(DateTimeFormatServiceInstance.formatCurrentDateTime).toHaveBeenCalledWith('UTC');
-      expect(DateTimeFormatServiceInstance.formatWorkTenure).toHaveBeenCalled();
-    });
+      expect(DateTimeFormatServiceInstance.formatCurrentDateTime).toHaveBeenCalledWith('UTC')
+      expect(DateTimeFormatServiceInstance.formatWorkTenure).toHaveBeenCalled()
+    })
 
     it('should handle API failures gracefully', async () => {
       // Mock all APIs to fail to test error handling
-      getWeatherData.mockRejectedValue(new Error('Weather API failed'));
-      getGitHubData.mockRejectedValue(new Error('GitHub API failed'));
-      getWakaTimeData.mockRejectedValue(new Error('WakaTime API failed'));
-      getTwitterData.mockRejectedValue(new Error('Twitter API failed'));
-      getCodeStatsData.mockRejectedValue(new Error('CodeStats API failed'));
-      getSpotifyData.mockRejectedValue(new Error('Spotify API failed'));
-      getGitHubOAuthData.mockRejectedValue(new Error('GitHub OAuth API failed'));
+      getWeatherData.mockRejectedValue(new Error('Weather API failed'))
+      getGitHubData.mockRejectedValue(new Error('GitHub API failed'))
+      getWakaTimeData.mockRejectedValue(new Error('WakaTime API failed'))
+      getTwitterData.mockRejectedValue(new Error('Twitter API failed'))
+      getCodeStatsData.mockRejectedValue(new Error('CodeStats API failed'))
+      getSpotifyData.mockRejectedValue(new Error('Spotify API failed'))
+      getGitHubOAuthData.mockRejectedValue(new Error('GitHub OAuth API failed'))
 
-      const result = await DataService.getDynamicData();
+      const result = await DataService.getDynamicData()
 
       // Should use defaults for failed APIs
-      expect(result.temperature).toBe('70°F');
-      expect(result.githubPublicRepos).toBe('10');
-      expect(result.wakatime_summary).toBe('No data'); // From config defaults
-      
+      expect(result.temperature).toBe('70°F')
+      expect(result.githubPublicRepos).toBe('10')
+      expect(result.wakatime_summary).toBe('No data') // From config defaults
+
       // Should log errors
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Error fetching APIs:',
-        expect.any(String)
-      );
-    });
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error fetching APIs:', expect.any(String))
+    })
 
     it('should handle custom profile data overrides', async () => {
       // Mock all APIs to return empty data
-      getWeatherData.mockResolvedValue({});
-      getGitHubData.mockResolvedValue({});
-      getWakaTimeData.mockResolvedValue({});
-      getTwitterData.mockResolvedValue({});
-      getCodeStatsData.mockResolvedValue({});
-      getSpotifyData.mockResolvedValue({});
-      getGitHubOAuthData.mockResolvedValue({});
+      getWeatherData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({})
+      getWakaTimeData.mockResolvedValue({})
+      getTwitterData.mockResolvedValue({})
+      getCodeStatsData.mockResolvedValue({})
+      getSpotifyData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({})
 
       const customData = {
         profile: {
@@ -236,148 +233,152 @@ describe('DataService', () => {
           COMPANY: 'Custom Company',
           CURRENT_PROJECT: 'Custom Project',
           TIMEZONE: 'America/New_York',
-          WORK_START_DATE: { year: 2021, month: 6, day: 15 }
-        }
-      };
+          WORK_START_DATE: { year: 2021, month: 6, day: 15 },
+        },
+      }
 
-      const result = await DataService.getDynamicData(customData);
+      const result = await DataService.getDynamicData(customData)
 
       // Should use custom profile data
-      expect(result.name).toBe('Custom Name');
-      expect(result.profession).toBe('Custom Profession');
-      expect(result.location).toBe('Custom City');
-      expect(result.company).toBe('Custom Company');
-      expect(result.currentProject).toBe('Custom Project');
+      expect(result.name).toBe('Custom Name')
+      expect(result.profession).toBe('Custom Profession')
+      expect(result.location).toBe('Custom City')
+      expect(result.company).toBe('Custom Company')
+      expect(result.currentProject).toBe('Custom Project')
 
       // Should use custom timezone for date formatting
-      expect(DateTimeFormatServiceInstance.formatCurrentDateTime)
-        .toHaveBeenCalledWith('America/New_York');
+      expect(DateTimeFormatServiceInstance.formatCurrentDateTime).toHaveBeenCalledWith(
+        'America/New_York'
+      )
 
       // Should calculate work tenure with custom start date
-      expect(DateTimeFormatServiceInstance.formatWorkTenure)
-        .toHaveBeenCalledWith(expect.any(Date));
-    });
+      expect(DateTimeFormatServiceInstance.formatWorkTenure).toHaveBeenCalledWith(expect.any(Date))
+    })
 
     it('should handle WORK_START_DATE as Date object', async () => {
       // Mock all APIs
-      getWeatherData.mockResolvedValue({});
-      getGitHubData.mockResolvedValue({});
-      getWakaTimeData.mockResolvedValue({});
-      getTwitterData.mockResolvedValue({});
-      getCodeStatsData.mockResolvedValue({});
-      getSpotifyData.mockResolvedValue({});
-      getGitHubOAuthData.mockResolvedValue({});
+      getWeatherData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({})
+      getWakaTimeData.mockResolvedValue({})
+      getTwitterData.mockResolvedValue({})
+      getCodeStatsData.mockResolvedValue({})
+      getSpotifyData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({})
 
-      const customWorkStartDate = new Date('2022-03-10T00:00:00.000Z');
+      const customWorkStartDate = new Date('2022-03-10T00:00:00.000Z')
       const customData = {
         profile: {
-          WORK_START_DATE: customWorkStartDate
-        }
-      };
+          WORK_START_DATE: customWorkStartDate,
+        },
+      }
 
-      await DataService.getDynamicData(customData);
+      await DataService.getDynamicData(customData)
 
       // Should call formatWorkTenure with the Date object
-      expect(DateTimeFormatServiceInstance.formatWorkTenure)
-        .toHaveBeenCalledWith(customWorkStartDate);
-    });
+      expect(DateTimeFormatServiceInstance.formatWorkTenure).toHaveBeenCalledWith(
+        customWorkStartDate
+      )
+    })
 
     it('should handle customData.workStartDate directly', async () => {
       // Mock all APIs
-      getWeatherData.mockResolvedValue({});
-      getGitHubData.mockResolvedValue({});
-      getWakaTimeData.mockResolvedValue({});
-      getTwitterData.mockResolvedValue({});
-      getCodeStatsData.mockResolvedValue({});
-      getSpotifyData.mockResolvedValue({});
-      getGitHubOAuthData.mockResolvedValue({});
+      getWeatherData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({})
+      getWakaTimeData.mockResolvedValue({})
+      getTwitterData.mockResolvedValue({})
+      getCodeStatsData.mockResolvedValue({})
+      getSpotifyData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({})
 
-      const customWorkStartDate = new Date('2021-08-01T00:00:00.000Z');
+      const customWorkStartDate = new Date('2021-08-01T00:00:00.000Z')
       const customData = {
-        workStartDate: customWorkStartDate
-      };
+        workStartDate: customWorkStartDate,
+      }
 
-      await DataService.getDynamicData(customData);
+      await DataService.getDynamicData(customData)
 
       // Should call formatWorkTenure with the direct workStartDate
-      expect(DateTimeFormatServiceInstance.formatWorkTenure)
-        .toHaveBeenCalledWith(customWorkStartDate);
-    });
+      expect(DateTimeFormatServiceInstance.formatWorkTenure).toHaveBeenCalledWith(
+        customWorkStartDate
+      )
+    })
 
     it('should fallback to UTC on timezone formatting error', async () => {
       // Mock all APIs
-      getWeatherData.mockResolvedValue({});
-      getGitHubData.mockResolvedValue({});
-      getWakaTimeData.mockResolvedValue({});
-      getTwitterData.mockResolvedValue({});
-      getCodeStatsData.mockResolvedValue({});
-      getSpotifyData.mockResolvedValue({});
-      getGitHubOAuthData.mockResolvedValue({});
+      getWeatherData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({})
+      getWakaTimeData.mockResolvedValue({})
+      getTwitterData.mockResolvedValue({})
+      getCodeStatsData.mockResolvedValue({})
+      getSpotifyData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({})
 
       // Mock DateTimeFormatService to throw error first, then succeed
       DateTimeFormatServiceInstance.formatCurrentDateTime
         .mockImplementationOnce(() => {
-          throw new Error('Invalid timezone');
+          throw new Error('Invalid timezone')
         })
-        .mockReturnValueOnce(mockDateTimeData);
+        .mockReturnValueOnce(mockDateTimeData)
 
       const customData = {
-        profile: { TIMEZONE: 'Invalid/Timezone' }
-      };
+        profile: { TIMEZONE: 'Invalid/Timezone' },
+      }
 
-      const result = await DataService.getDynamicData(customData);
+      const result = await DataService.getDynamicData(customData)
 
       // Should have called formatCurrentDateTime twice (once with invalid, once with UTC)
-      expect(DateTimeFormatServiceInstance.formatCurrentDateTime).toHaveBeenCalledTimes(2);
-      expect(DateTimeFormatServiceInstance.formatCurrentDateTime).toHaveBeenCalledWith('Invalid/Timezone');
-      expect(DateTimeFormatServiceInstance.formatCurrentDateTime).toHaveBeenCalledWith('UTC');
-      
-      expect(result.currentDayOfWeek).toBe('Monday');
+      expect(DateTimeFormatServiceInstance.formatCurrentDateTime).toHaveBeenCalledTimes(2)
+      expect(DateTimeFormatServiceInstance.formatCurrentDateTime).toHaveBeenCalledWith(
+        'Invalid/Timezone'
+      )
+      expect(DateTimeFormatServiceInstance.formatCurrentDateTime).toHaveBeenCalledWith('UTC')
+
+      expect(result.currentDayOfWeek).toBe('Monday')
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Error formatting date/time')
-      );
-    });
+      )
+    })
 
     it('should handle critical error and return minimal dataset', async () => {
       // Mock DateTimeFormatService to throw critical error
       DateTimeFormatServiceInstance.formatCurrentDateTime.mockImplementation(() => {
-        throw new Error('Critical formatting error');
-      });
+        throw new Error('Critical formatting error')
+      })
 
-      const result = await DataService.getDynamicData();
+      const result = await DataService.getDynamicData()
 
       // Should return baseData with defaults
-      expect(result.name).toBe('Test User');
-      expect(result.temperature).toBe('70°F');
-      expect(result.currentDayOfWeek).toBe('N/A'); // Base data fallback
+      expect(result.name).toBe('Test User')
+      expect(result.temperature).toBe('70°F')
+      expect(result.currentDayOfWeek).toBe('N/A') // Base data fallback
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         'Critical error in getDynamicData:',
         'Critical formatting error'
-      );
-      expect(consoleWarnSpy).toHaveBeenCalledWith('Returning minimal dataset.');
-    });
+      )
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Returning minimal dataset.')
+    })
 
     it('should preserve additional customData properties', async () => {
       // Mock all APIs
-      getWeatherData.mockResolvedValue({});
-      getGitHubData.mockResolvedValue({});
-      getWakaTimeData.mockResolvedValue({});
-      getTwitterData.mockResolvedValue({});
-      getCodeStatsData.mockResolvedValue({});
-      getSpotifyData.mockResolvedValue({});
-      getGitHubOAuthData.mockResolvedValue({});
+      getWeatherData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({})
+      getWakaTimeData.mockResolvedValue({})
+      getTwitterData.mockResolvedValue({})
+      getCodeStatsData.mockResolvedValue({})
+      getSpotifyData.mockResolvedValue({})
+      getGitHubOAuthData.mockResolvedValue({})
 
       const customData = {
         customProperty: 'custom value',
-        anotherProperty: 42
-      };
+        anotherProperty: 42,
+      }
 
-      const result = await DataService.getDynamicData(customData);
+      const result = await DataService.getDynamicData(customData)
 
       // Should preserve custom properties
-      expect(result.customProperty).toBe('custom value');
-      expect(result.anotherProperty).toBe(42);
-    });
-  });
-});
+      expect(result.customProperty).toBe('custom value')
+      expect(result.anotherProperty).toBe(42)
+    })
+  })
+})

--- a/tests/unit/services/data_sources/githubDataSource.test.js
+++ b/tests/unit/services/data_sources/githubDataSource.test.js
@@ -1,174 +1,92 @@
-// tests/unit/services/data_sources/githubDataSource.test.js - FIXED
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { config } from '../../../../src/config/config.js';
+// tests/unit/services/data_sources/githubDataSource.test.js
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { config } from '../../../../src/config/config.js'
 
-vi.mock('node-fetch', () => ({
-  default: vi.fn()
-}));
+let getGitHubData
 
-describe('githubDataSource', () => {
-  let mockFetch;
-  let getGitHubData;
+beforeEach(async () => {
+  vi.resetModules() // reset module-level cache between tests
+  ;({ getGitHubData } = await import('../../../../src/services/data_sources/githubDataSource.js'))
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.useFakeTimers();
-    
-    // Clear module cache and re-import
-    vi.resetModules();
-    const module = await import('../../../../src/services/data_sources/githubDataSource.js');
-    getGitHubData = module.getGitHubData;
-    
-    mockFetch = vi.fn();
-    if (typeof fetch === 'undefined') {
-      global.fetch = undefined;
-    }
-  });
+const noSleep = () => Promise.resolve()
+const okFetch = (body) =>
+  vi.fn().mockResolvedValue({ ok: true, status: 200, statusText: 'OK', json: async () => body })
 
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    if (global.fetch === undefined) {
-      delete global.fetch;
-    }
-  });
+describe('githubDataSource — discriminated results', () => {
+  it('returns an ok result with live values', async () => {
+    const fetchImpl = okFetch({ public_repos: 42, followers: 100 })
+    const r = await getGitHubData({ fetchImpl, sleep: noSleep })
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({ githubPublicRepos: '42', githubFollowers: '100' })
+    expect(typeof r.fetchedAt).toBe('number')
+  })
 
-  describe('Successful API Fetch & Caching', () => {
-    it('should fetch GitHub data successfully', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
+  it('caches an ok result (second call does not refetch)', async () => {
+    const fetchImpl = okFetch({ public_repos: 50, followers: 150 })
+    await getGitHubData({ fetchImpl, sleep: noSleep })
+    const r2 = await getGitHubData({ fetchImpl, sleep: noSleep })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(r2.status).toBe('ok')
+  })
+
+  it('refetches after the cache TTL expires', async () => {
+    vi.useFakeTimers()
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          public_repos: 42,
-          followers: 100
-        })
-      });
-
-      const result = await getGitHubData();
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        `https://api.github.com/users/${config.profile.GITHUB_USERNAME}`,
-        { headers: { 'Accept': 'application/vnd.github.v3+json' } }
-      );
-      expect(result).toEqual({
-        githubPublicRepos: '42',
-        githubFollowers: '100'
-      });
-    });
-
-    it('should use cached data on second call', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        json: async () => ({ public_repos: 10, followers: 20 }),
+      })
+      .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          public_repos: 50,
-          followers: 150
-        })
-      });
+        status: 200,
+        json: async () => ({ public_repos: 15, followers: 25 }),
+      })
+    await getGitHubData({ fetchImpl, sleep: noSleep })
+    vi.advanceTimersByTime(config.cache.GITHUB_CACHE_TTL_MS + 1000)
+    const r = await getGitHubData({ fetchImpl, sleep: noSleep })
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(r.value.githubPublicRepos).toBe('15')
+  })
 
-      const result1 = await getGitHubData();
-      const result2 = await getGitHubData();
+  it('returns a FALLBACK (defaults + error) on an auth error — distinguishable from ok', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+        json: async () => ({}),
+      })
+    const r = await getGitHubData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.status).toBe('fallback')
+    expect(r.value).toEqual({
+      githubPublicRepos: config.apiDefaults.GITHUB_PUBLIC_REPOS,
+      githubFollowers: config.apiDefaults.GITHUB_FOLLOWERS,
+    })
+    expect(r.error.status).toBe(401)
+  })
 
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(result2).toEqual(result1);
-    });
+  it('returns a FALLBACK on a network error', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('Network failure'))
+    const r = await getGitHubData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.status).toBe('fallback')
+    expect(r.value.githubPublicRepos).toBe(config.apiDefaults.GITHUB_PUBLIC_REPOS)
+  })
 
-    it('should fetch new data after cache expires', async () => {
-      global.fetch = mockFetch;
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ public_repos: 10, followers: 20 })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ public_repos: 15, followers: 25 })
-        });
+  it('does not cache a fallback (recovers on the next call)', async () => {
+    const failing = vi.fn().mockRejectedValue(new Error('down'))
+    const first = await getGitHubData({ fetchImpl: failing, sleep: noSleep, retries: 0 })
+    expect(first.status).toBe('fallback')
 
-      await getGitHubData();
-      vi.advanceTimersByTime(config.cache.GITHUB_CACHE_TTL_MS + 1000);
-      const result = await getGitHubData();
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(result).toEqual({
-        githubPublicRepos: '15',
-        githubFollowers: '25'
-      });
-    });
-  });
-
-  describe('API Error Handling', () => {
-    const errorTests = [
-      { status: 401, description: 'Unauthorized' },
-      { status: 403, description: 'Rate limit' },
-      { status: 429, description: 'Too many requests' },
-      { status: 404, description: 'User not found' },
-      { status: 500, description: 'Server error' }
-    ];
-
-    errorTests.forEach(({ status, description }) => {
-      it(`should handle ${status} ${description} error`, async () => {
-        global.fetch = mockFetch;
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status,
-          statusText: description
-        });
-
-        const result = await getGitHubData();
-
-        expect(result).toEqual({
-          githubPublicRepos: config.apiDefaults.GITHUB_PUBLIC_REPOS,
-          githubFollowers: config.apiDefaults.GITHUB_FOLLOWERS
-        });
-      });
-    });
-
-    it('should handle network errors', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockRejectedValueOnce(new Error('Network failure'));
-
-      const result = await getGitHubData();
-
-      expect(result).toEqual({
-        githubPublicRepos: config.apiDefaults.GITHUB_PUBLIC_REPOS,
-        githubFollowers: config.apiDefaults.GITHUB_FOLLOWERS
-      });
-    });
-  });
-
-  describe('Node Environment', () => {
-    it('should use node-fetch in Node environment', async () => {
-      delete global.fetch;
-      const nodeFetch = (await import('node-fetch')).default;
-      nodeFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          public_repos: 30,
-          followers: 60
-        })
-      });
-
-      const result = await getGitHubData();
-
-      expect(nodeFetch).toHaveBeenCalled();
-      expect(result).toEqual({
-        githubPublicRepos: '30',
-        githubFollowers: '60'
-      });
-    });
-
-    it('should handle errors in Node environment', async () => {
-      delete global.fetch;
-      const nodeFetch = (await import('node-fetch')).default;
-      nodeFetch.mockRejectedValueOnce(new Error('Node fetch error'));
-
-      const result = await getGitHubData();
-
-      expect(result).toEqual({
-        githubPublicRepos: config.apiDefaults.GITHUB_PUBLIC_REPOS,
-        githubFollowers: config.apiDefaults.GITHUB_FOLLOWERS
-      });
-    });
-  });
-});
+    const recovered = okFetch({ public_repos: 1, followers: 2 })
+    const second = await getGitHubData({ fetchImpl: recovered, sleep: noSleep })
+    expect(second.status).toBe('ok')
+  })
+})

--- a/tests/unit/services/data_sources/githubOAuthDataSource.test.js
+++ b/tests/unit/services/data_sources/githubOAuthDataSource.test.js
@@ -1,428 +1,160 @@
-// tests/unit/services/data_sources/githubOAuthDataSource.test.js - FIXED
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { config } from '../../../../src/config/config.js';
-import githubOAuthService from '../../../../src/services/auth/githubOAuthService.js';
-
-vi.mock('node-fetch', () => ({
-  default: vi.fn()
-}));
+// tests/unit/services/data_sources/githubOAuthDataSource.test.js
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { config } from '../../../../src/config/config.js'
+import githubOAuthService from '../../../../src/services/auth/githubOAuthService.js'
 
 vi.mock('../../../../src/services/auth/githubOAuthService.js', () => ({
-  default: {
-    getAccessToken: vi.fn()
-  }
-}));
+  default: { getAccessToken: vi.fn() },
+}))
 
-describe('githubOAuthDataSource', () => {
-  let mockFetch;
-  let getGitHubOAuthData;
-  const originalEnv = process.env;
+let getGitHubOAuthData
+const originalEnv = process.env
+const noSleep = () => Promise.resolve()
+const json = (body) => ({ ok: true, status: 200, statusText: 'OK', json: async () => body })
 
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.useFakeTimers();
-    
-    // Reset module
-    vi.resetModules();
-    const module = await import('../../../../src/services/data_sources/githubOAuthDataSource.js');
-    getGitHubOAuthData = module.getGitHubOAuthData;
-    
-    process.env = { ...originalEnv };
-    mockFetch = vi.fn();
-    
-    if (typeof fetch === 'undefined') {
-      global.fetch = undefined;
-    }
-  });
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.resetModules()
+  ;({ getGitHubOAuthData } = await import(
+    '../../../../src/services/data_sources/githubOAuthDataSource.js'
+  ))
+  // Default to CI mode with a direct token for most tests.
+  process.env = { ...originalEnv, GITHUB_DATA_MODE: 'ci', PAT_GITHUB_OAUTH: 'ci-token' }
+})
 
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    process.env = originalEnv;
-    if (global.fetch === undefined) {
-      delete global.fetch;
-    }
-  });
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  process.env = originalEnv
+})
 
-  describe('CI Mode', () => {
-    it('should use direct token in CI mode', async () => {
-      process.env.GITHUB_DATA_MODE = 'ci';
-      process.env.PAT_GITHUB_OAUTH = 'ci-token';
-      global.fetch = mockFetch;
-      
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'ciuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => []
-        });
+describe('githubOAuthDataSource — discriminated results', () => {
+  it('uses the CI token and returns ok with computed stats', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(json({ login: 'testuser' }))
+      .mockResolvedValueOnce(
+        json([
+          {
+            fork: false,
+            owner: { login: 'testuser' },
+            stargazers_count: 10,
+            language: 'JavaScript',
+          },
+          { fork: false, owner: { login: 'testuser' }, stargazers_count: 20, language: 'Python' },
+          { fork: true, owner: { login: 'testuser' }, stargazers_count: 100, language: 'Go' },
+        ])
+      )
+      .mockResolvedValueOnce(json([{ type: 'PushEvent', payload: { size: 3 } }]))
 
-      await getGitHubOAuthData();
+    const r = await getGitHubOAuthData({ fetchImpl, sleep: noSleep, retries: 0 })
 
-      expect(githubOAuthService.getAccessToken).not.toHaveBeenCalled();
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.github.com/user',
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'token ci-token'
-          })
-        })
-      );
-    });
-  });
+    expect(githubOAuthService.getAccessToken).not.toHaveBeenCalled()
+    expect(r.status).toBe('ok')
+    expect(r.value.githubTotalStars).toBe('30') // fork excluded
+    expect(r.value.githubContributedRepos).toBe('2')
+    expect(r.value.githubPrimaryLanguage).toBe('JavaScript')
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://api.github.com/user')
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe('token ci-token')
+  })
 
-  describe('OAuth Flow', () => {
-    it('should use OAuth token in regular mode', async () => {
-      githubOAuthService.getAccessToken.mockResolvedValueOnce('oauth-token');
-      global.fetch = mockFetch;
-      
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'oauthuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => []
-        });
+  it('uses the OAuth service token when not in CI mode', async () => {
+    process.env = { ...originalEnv }
+    delete process.env.GITHUB_DATA_MODE
+    delete process.env.PAT_GITHUB_OAUTH
+    githubOAuthService.getAccessToken.mockResolvedValueOnce('oauth-token')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(json({ login: 'u' }))
+      .mockResolvedValueOnce(json([]))
 
-      await getGitHubOAuthData();
+    const r = await getGitHubOAuthData({ fetchImpl, sleep: noSleep, retries: 0 })
 
-      expect(githubOAuthService.getAccessToken).toHaveBeenCalled();
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.github.com/user',
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'token oauth-token'
-          })
-        })
-      );
-    });
+    expect(githubOAuthService.getAccessToken).toHaveBeenCalled()
+    expect(r.status).toBe('ok')
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe('token oauth-token')
+  })
 
-    it('should handle OAuth token errors', async () => {
-      githubOAuthService.getAccessToken.mockRejectedValueOnce(
-        new Error('No token')
-      );
-      global.fetch = mockFetch;
+  it('returns a FALLBACK when no token is available', async () => {
+    process.env = { ...originalEnv }
+    delete process.env.GITHUB_DATA_MODE
+    delete process.env.PAT_GITHUB_OAUTH
+    githubOAuthService.getAccessToken.mockRejectedValueOnce(new Error('No token'))
+    const fetchImpl = vi.fn()
 
-      const result = await getGitHubOAuthData();
+    const r = await getGitHubOAuthData({ fetchImpl, sleep: noSleep })
 
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        githubTotalStars: config.apiDefaults.GITHUB_TOTAL_STARS,
-        githubCommitsLastYear: config.apiDefaults.GITHUB_COMMITS_LAST_YEAR,
-        githubContributedRepos: config.apiDefaults.GITHUB_CONTRIBUTED_REPOS,
-        githubPrimaryLanguage: config.apiDefaults.GITHUB_PRIMARY_LANGUAGE
-      });
-    });
-  });
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(r.status).toBe('fallback')
+    expect(r.value).toEqual({
+      githubTotalStars: config.apiDefaults.GITHUB_TOTAL_STARS,
+      githubCommitsLastYear: config.apiDefaults.GITHUB_COMMITS_LAST_YEAR,
+      githubContributedRepos: config.apiDefaults.GITHUB_CONTRIBUTED_REPOS,
+      githubPrimaryLanguage: config.apiDefaults.GITHUB_PRIMARY_LANGUAGE,
+    })
+  })
 
-  describe('Data Processing', () => {
-    beforeEach(() => {
-      githubOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-    });
-
-    it('should calculate total stars from owned repos', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'testuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            {
-              fork: false,
-              owner: { login: 'testuser' },
-              stargazers_count: 10,
-              language: 'JavaScript'
-            },
-            {
-              fork: false,
-              owner: { login: 'testuser' },
-              stargazers_count: 20,
-              language: 'Python'
-            },
-            {
-              fork: true, // Should be excluded
-              owner: { login: 'testuser' },
-              stargazers_count: 100,
-              language: 'Go'
-            }
-          ]
-        });
-
-      const result = await getGitHubOAuthData();
-
-      expect(result.githubTotalStars).toBe('30'); // 10 + 20, excluding fork
-      expect(result.githubContributedRepos).toBe('2');
-      expect(result.githubPrimaryLanguage).toBe('JavaScript'); // Most common
-    });
-
-    it('should determine primary language correctly', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'testuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            { fork: false, owner: { login: 'testuser' }, language: 'Python' },
-            { fork: false, owner: { login: 'testuser' }, language: 'Python' },
-            { fork: false, owner: { login: 'testuser' }, language: 'Python' },
-            { fork: false, owner: { login: 'testuser' }, language: 'JavaScript' },
-            { fork: false, owner: { login: 'testuser' }, language: 'JavaScript' },
-            { fork: false, owner: { login: 'testuser' }, language: null }
-          ]
-        });
-
-      const result = await getGitHubOAuthData();
-
-      expect(result.githubPrimaryLanguage).toBe('Python'); // 3 > 2
-    });
-
-    it('should handle no owned repos', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'testuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            { fork: true, owner: { login: 'testuser' } },
-            { fork: false, owner: { login: 'otheruser' } }
-          ]
-        });
-
-      const result = await getGitHubOAuthData();
-
-      expect(result.githubTotalStars).toBe('0');
-      expect(result.githubContributedRepos).toBe('0');
-      expect(result.githubPrimaryLanguage).toBe('None');
-    });
-
-    it('should estimate commits from events', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'testuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            { fork: false, owner: { login: 'testuser' }, language: 'Go' }
-          ]
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            { type: 'PushEvent', payload: { size: 3 } },
-            { type: 'PushEvent', payload: { size: 2 } },
-            { type: 'IssueEvent', payload: {} }, // Should be ignored
-            { type: 'PushEvent', payload: { size: 1 } }
-          ]
-        });
-
-      const result = await getGitHubOAuthData();
-
-      // 6 commits total, scaled to annual (6 * 365/30 = 73)
-      expect(result.githubCommitsLastYear).toBe('73+');
-    });
-
-    it('should cap unreasonable commit estimates', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'testuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            { fork: false, owner: { login: 'testuser' } }
-          ]
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            { type: 'PushEvent', payload: { size: 1000 } }
-          ]
-        });
-
-      const result = await getGitHubOAuthData();
-
-      expect(result.githubCommitsLastYear).toBe('3000+'); // Capped at max
-    });
-
-    it('should handle events API errors gracefully', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'testuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            { fork: false, owner: { login: 'testuser' } }
-          ]
-        })
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 404
-        });
-
-      const result = await getGitHubOAuthData();
-
-      expect(result.githubCommitsLastYear).toBe(
-        config.apiDefaults.GITHUB_COMMITS_LAST_YEAR
-      );
-    });
-  });
-
-  describe('Caching', () => {
-    beforeEach(() => {
-      githubOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-    });
-
-    it('should use cached data', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'testuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => []
-        });
-
-      await getGitHubOAuthData();
-      
-      // Clear mocks to check second call
-      githubOAuthService.getAccessToken.mockClear();
-      mockFetch.mockClear();
-      
-      const result = await getGitHubOAuthData();
-
-      expect(githubOAuthService.getAccessToken).not.toHaveBeenCalled();
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toBeDefined();
-    });
-
-    it('should refresh after cache expires', async () => {
-      githubOAuthService.getAccessToken
-        .mockResolvedValueOnce('token1')
-        .mockResolvedValueOnce('token2');
-      
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'user1' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => []
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'user2' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => []
-        });
-
-      await getGitHubOAuthData();
-      vi.advanceTimersByTime(config.cache.GITHUB_OAUTH_CACHE_TTL_MS + 1000);
-      await getGitHubOAuthData();
-
-      expect(mockFetch).toHaveBeenCalledTimes(4);
-    });
-  });
-
-  describe('Error Handling', () => {
-    beforeEach(() => {
-      githubOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-    });
-
-    it('should handle user API errors', async () => {
-      mockFetch.mockResolvedValueOnce({
+  it('returns a FALLBACK on a user API error (distinguishable, carries status)', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({
         ok: false,
         status: 401,
-        statusText: 'Unauthorized'
-      });
+        statusText: 'Unauthorized',
+        json: async () => ({}),
+      })
+    const r = await getGitHubOAuthData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.status).toBe('fallback')
+    expect(r.error.status).toBe(401)
+  })
 
-      const result = await getGitHubOAuthData();
+  it('estimates commits from push events', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(json({ login: 'testuser' }))
+      .mockResolvedValueOnce(json([{ fork: false, owner: { login: 'testuser' }, language: 'Go' }]))
+      .mockResolvedValueOnce(
+        json([
+          { type: 'PushEvent', payload: { size: 3 } },
+          { type: 'PushEvent', payload: { size: 2 } },
+          { type: 'IssuesEvent', payload: {} },
+          { type: 'PushEvent', payload: { size: 1 } },
+        ])
+      )
+    const r = await getGitHubOAuthData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.value.githubCommitsLastYear).toBe('73+') // 6 * 365/30 = 73
+  })
 
-      expect(result).toEqual({
-        githubTotalStars: config.apiDefaults.GITHUB_TOTAL_STARS,
-        githubCommitsLastYear: config.apiDefaults.GITHUB_COMMITS_LAST_YEAR,
-        githubContributedRepos: config.apiDefaults.GITHUB_CONTRIBUTED_REPOS,
-        githubPrimaryLanguage: config.apiDefaults.GITHUB_PRIMARY_LANGUAGE
-      });
-    });
+  it('caps unreasonable commit estimates', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(json({ login: 'testuser' }))
+      .mockResolvedValueOnce(json([{ fork: false, owner: { login: 'testuser' } }]))
+      .mockResolvedValueOnce(json([{ type: 'PushEvent', payload: { size: 1000 } }]))
+    const r = await getGitHubOAuthData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.value.githubCommitsLastYear).toBe('3000+')
+  })
 
-    it('should handle repos API errors', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'testuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 500,
-          statusText: 'Server Error'
-        });
+  it('stays ok with default commits when the events API fails (partial degradation)', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(json({ login: 'testuser' }))
+      .mockResolvedValueOnce(json([{ fork: false, owner: { login: 'testuser' } }]))
+      .mockResolvedValueOnce({ ok: false, status: 404, statusText: '', json: async () => ({}) })
+    const r = await getGitHubOAuthData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.status).toBe('ok')
+    expect(r.value.githubCommitsLastYear).toBe(config.apiDefaults.GITHUB_COMMITS_LAST_YEAR)
+  })
 
-      const result = await getGitHubOAuthData();
-
-      expect(result).toEqual({
-        githubTotalStars: config.apiDefaults.GITHUB_TOTAL_STARS,
-        githubCommitsLastYear: config.apiDefaults.GITHUB_COMMITS_LAST_YEAR,
-        githubContributedRepos: config.apiDefaults.GITHUB_CONTRIBUTED_REPOS,
-        githubPrimaryLanguage: config.apiDefaults.GITHUB_PRIMARY_LANGUAGE
-      });
-    });
-
-    it('should handle network errors', async () => {
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-      const result = await getGitHubOAuthData();
-
-      expect(result).toEqual({
-        githubTotalStars: config.apiDefaults.GITHUB_TOTAL_STARS,
-        githubCommitsLastYear: config.apiDefaults.GITHUB_COMMITS_LAST_YEAR,
-        githubContributedRepos: config.apiDefaults.GITHUB_CONTRIBUTED_REPOS,
-        githubPrimaryLanguage: config.apiDefaults.GITHUB_PRIMARY_LANGUAGE
-      });
-    });
-  });
-
-  describe('Node Environment', () => {
-    it('should use node-fetch in Node', async () => {
-      githubOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      delete global.fetch;
-      
-      const nodeFetch = (await import('node-fetch')).default;
-      nodeFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ login: 'nodeuser' })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => []
-        });
-
-      await getGitHubOAuthData();
-
-      expect(nodeFetch).toHaveBeenCalled();
-    });
-  });
-});
+  it('caches an ok result (second call does not refetch)', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(json({ login: 'u' }))
+      .mockResolvedValueOnce(json([]))
+    await getGitHubOAuthData({ fetchImpl, sleep: noSleep, retries: 0 })
+    const callsAfterFirst = fetchImpl.mock.calls.length
+    const r2 = await getGitHubOAuthData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(fetchImpl).toHaveBeenCalledTimes(callsAfterFirst)
+    expect(r2.status).toBe('ok')
+  })
+})


### PR DESCRIPTION
## feat(reliability): shared HTTP client + discriminated source results (PR-5a)

The reliability-spine foundation. Eliminates the **"green build with invisible fallback"** failure mode at the data-source layer — the root cause of the silent stale-stats defect. Sources no longer return default values indistinguishable from live data.

### How it eliminates the failure mode
Before: every source caught all errors and returned `config.apiDefaults.*`, so the orchestrator (and CI) could not tell a live fetch from a quiet fallback — the build stayed green while the SVG showed placeholder numbers. Now each GitHub source returns a **discriminated result** carrying its status, and `DataService` records per-source health that PR-5b will turn into a manifest + staleness guard.

### New primitives (`src/services/utils/`)
- **`httpClient.js` (`fetchJson`)** — per-attempt `AbortSignal` timeout; bounded **retry/backoff** for transient failures (5xx/429/408/425/network); **fail-fast on auth/config 4xx** (401/403/404 never retried); normalized `HttpError`. `fetchImpl`/`sleep` injectable for deterministic tests.
- **`sourceResult.js`** — `ok{value,fetchedAt}` / `fallback{value,error,fetchedAt}` / `error{error,fetchedAt}` + log-safe `normalizeError` (no stack, no secrets).

### GitHub stats sources converted (the live product-trust failure)
- `githubDataSource` + `githubOAuthDataSource` now use `fetchJson` and return discriminated results — `ok` on success, `fallback` (defaults **+** error) on failure. Dead `node-fetch` branch removed. The (fabricated) commit estimate is preserved — GraphQL replacement is **PR-5c**.

### Orchestrator
- `DataService` unwraps `github`/`githubOAuth` `.value` for rendering **and** records `{source,status,error,fetchedAt}` on `this.lastSourceStatuses` — the machine-visible status **PR-5b** consumes.

### Scope (as agreed)
GitHub sources only (other sources convert in a later pass). **No** Actions alerting (PR-5b), **no** SVG design change, **no** GraphQL commits (PR-5c).

### Acceptance
- [x] Unit tests prove timeout behavior (real `AbortSignal` abort).
- [x] Unit tests prove retry/backoff (growing delay, exhaustion).
- [x] Unit tests prove auth/config errors are **not** retried (401/404 fail-fast, no sleep).
- [x] GitHub source tests prove `ok` / `fallback` are distinguishable (status + error carried).
- [x] Existing build/render flow still produces an SVG (integration green).
- [x] `npm run verify` passes.

### Verify
`npm run verify` → **481 tests pass**, coverage **90.74% stmts / 85.6% br / 97.5% fn** (above thresholds), configurator build green, eslint clean.

> The four `style:` commits are isolated, mechanical prettier reformats of pre-existing semicolon'd files (`DataService.js`, two test files) so the logic diffs stay reviewable — same pattern as earlier PRs. New files were authored already-conformant.
