### PR TITLE
fix(reliability): reset DataService source statuses per run (PR-5a follow-up)

### DIFF
--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -20,6 +20,10 @@ class DataService {
   lastSourceStatuses = []
 
   async getDynamicData(customData = {}) {
+    // Reset per-run status first so a run that fails early can never surface a
+    // previous run's statuses through this reused singleton.
+    this.lastSourceStatuses = []
+
     // initialise base object so we have something even on catastrophic failure
     let baseData = {
       currentDayOfWeek: 'N/A',

--- a/tests/unit/services/__tests__/DataService.test.js
+++ b/tests/unit/services/__tests__/DataService.test.js
@@ -224,6 +224,25 @@ describe('DataService', () => {
       expect(bySource.githubOAuth.status).toBe('ok')
     })
 
+    it('resets source statuses each run (no stale leak when a later run fails early)', async () => {
+      // Run 1: populate statuses with a github fallback.
+      getWeatherData.mockResolvedValue({})
+      getWakaTimeData.mockResolvedValue({})
+      getTwitterData.mockResolvedValue({})
+      getCodeStatsData.mockResolvedValue({})
+      getSpotifyData.mockResolvedValue({})
+      getGitHubData.mockResolvedValue({ status: 'fallback', value: {}, error: { message: 'x' } })
+      getGitHubOAuthData.mockResolvedValue({ status: 'ok', value: {} })
+      await DataService.getDynamicData()
+      expect(DataService.lastSourceStatuses.some((s) => s.source === 'github')).toBe(true)
+
+      // Run 2: a source throws so the remote phase fails before statuses are populated.
+      // The reused singleton must NOT retain run 1's statuses.
+      getWeatherData.mockRejectedValueOnce(new Error('boom'))
+      await DataService.getDynamicData()
+      expect(DataService.lastSourceStatuses).toEqual([])
+    })
+
     it('should handle API failures gracefully', async () => {
       // Mock all APIs to fail to test error handling
       getWeatherData.mockRejectedValue(new Error('Weather API failed'))


### PR DESCRIPTION
## fix(reliability): reset `lastSourceStatuses` per run — follow-up to PR-5a

Addresses the PM's product note on PR-5a.

**Bug:** `DataService.lastSourceStatuses` was assigned only *after* the remote fetch. A run that fails early — a source throws → `Promise.all` rejects → `catch`, or a fatal date-format error → outer `catch` — never reassigns it. Since `DataService` is a reused singleton (notably **per-request in the preview server**), the next caller would see the **previous** run's source health. Stale, misleading status — exactly what PR-5b must not build a staleness guard on top of.

**Fix:** reset `this.lastSourceStatuses = []` as the **first statement** of `getDynamicData()`, so each run reports only its own sources (empty if it failed before assessing them).

### Test (TDD)
New test: run 1 records a github `fallback`; run 2 fails early (a source throws) → `lastSourceStatuses` is `[]`, not run 1's data. (Fails before the fix, passes after.)

### Scope
One-line behavior fix + its test. No contract change, no new surface. PR-5b still consumes `lastSourceStatuses` — now safely per-run.

### Verify
`npm run verify` → **482 tests pass**, coverage 90.8% stmts, configurator build green, lint clean.
