### PR TITLE
feat(reliability): convert remaining data sources to discriminated results (PR-5a.2)

### DIFF
--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -101,32 +101,25 @@ class DataService {
             getSpotifyData(),
             getGitHubOAuthData(),
           ])
-        // github + githubOAuth return discriminated results { status, value, error, fetchedAt }.
+        // All sources now return discriminated results { status, value, error, fetchedAt }.
         // Unwrap their values for rendering and record per-source status so PR-5b can build a
         // staleness manifest — a fallback is no longer indistinguishable from live data.
+        const sources = { weather, github, wakatime, twitter, codestats, spotify, githubOAuth }
         Object.assign(
           baseData,
-          weather,
+          weather.value || {},
           github.value || {},
-          wakatime,
-          codestats,
-          spotify,
+          wakatime.value || {},
+          codestats.value || {},
+          spotify.value || {},
           githubOAuth.value || {}
         )
-        this.lastSourceStatuses = [
-          {
-            source: 'github',
-            status: github.status,
-            error: github.error,
-            fetchedAt: github.fetchedAt,
-          },
-          {
-            source: 'githubOAuth',
-            status: githubOAuth.status,
-            error: githubOAuth.error,
-            fetchedAt: githubOAuth.fetchedAt,
-          },
-        ]
+        this.lastSourceStatuses = Object.entries(sources).map(([source, r]) => ({
+          source,
+          status: r.status,
+          error: r.error,
+          fetchedAt: r.fetchedAt,
+        }))
 
         // Handle Twitter followers with manual input priority
         if (customData.profile?.TWITTER_FOLLOWERS) {
@@ -135,9 +128,9 @@ class DataService {
         } else if (config.profile.TWITTER_FOLLOWERS) {
           // Then config.profile.TWITTER_FOLLOWERS (from src/config/config.js)
           baseData.twitterFollowers = config.profile.TWITTER_FOLLOWERS
-        } else if (config.twitter.enabled_api_fetch && twitter.twitterFollowers) {
+        } else if (config.twitter.enabled_api_fetch && twitter.value?.twitterFollowers) {
           // Then, if API fetching is enabled and successful, use that value
-          baseData.twitterFollowers = twitter.twitterFollowers
+          baseData.twitterFollowers = twitter.value.twitterFollowers
         }
         // Finally, fall back to config.apiDefaults.TWITTER_FOLLOWERS (already set above)
       } catch (apiErr) {

--- a/src/services/data_sources/codestatsDataSource.js
+++ b/src/services/data_sources/codestatsDataSource.js
@@ -1,109 +1,40 @@
 /**
  * codestatsDataSource.js
- * Responsible for fetching and caching Code::Stats user XP data
- * Single Responsibility: Code::Stats data acquisition
+ * Single Responsibility: Code::Stats total XP acquisition
+ *
+ * Returns a discriminated source result (see sourceResult.js): `ok` with live
+ * value (or `ok({})` when not configured — an intentional skip), or `fallback`
+ * carrying the default AND the error.
  */
-import { config } from '../../config/config.js';
+import { config } from '../../config/config.js'
+import { fetchJson } from '../utils/httpClient.js'
+import { ok, fallback } from '../utils/sourceResult.js'
 
-// Initialize module-level cache store
-let codestatsCache = { data: null, expiresAt: 0 };
+let codestatsCache = { result: null, expiresAt: 0 }
 
-/**
- * Fetch Code::Stats total XP with robust error handling and caching
- * @returns {Promise<Object>} - Code::Stats data (total XP)
- */
-async function getCodeStatsData() {
+async function getCodeStatsData(deps = {}) {
+  const username = config.profile.CODESTATS_USERNAME
+  if (!username) return ok({}) // not configured — skip
+
+  if (codestatsCache.result && Date.now() < codestatsCache.expiresAt) {
+    return codestatsCache.result
+  }
+
   try {
-    // Check if Code::Stats username is configured
-    const username = config.profile.CODESTATS_USERNAME;
-    if (!username) {
-      console.info('Code::Stats username not configured - skipping Code::Stats call.');
-      return {};
+    const data = await fetchJson(
+      `https://codestats.net/api/users/${encodeURIComponent(username)}`,
+      { ...deps }
+    )
+    if (!data || typeof data.total_xp !== 'number') {
+      throw new Error('Code::Stats API returned invalid or missing total_xp data.')
     }
-
-    // Check if valid cached data exists
-    if (codestatsCache.data && Date.now() < codestatsCache.expiresAt) {
-      console.info('Using cached Code::Stats data.');
-      return codestatsCache.data;
-    }
-
-    // For browser environments
-    if (typeof fetch === 'function') {
-      const response = await fetch(`https://codestats.net/api/users/${encodeURIComponent(username)}`);
-      
-      if (!response.ok) {
-        // Handle specific HTTP error status codes
-        switch (response.status) {
-          case 404:
-            throw new Error(`Code::Stats API error (${response.status}): User '${username}' not found. Check your CODESTATS_USERNAME in config.`);
-          default:
-            throw new Error(`Code::Stats API server error (${response.status}): ${response.statusText}`);
-        }
-      }
-      
-      const data = await response.json();
-      
-      if (data && typeof data.total_xp === 'number') {
-        const result = {
-          codestatsXP: data.total_xp.toString()
-        };
-
-        // Cache the successful API response
-        codestatsCache.data = result;
-        codestatsCache.expiresAt = Date.now() + config.cache.CODESTATS_CACHE_TTL_MS;
-        console.info('Code::Stats data fetched from API and cached.');
-        
-        return result;
-      } else {
-        throw new Error("Code::Stats API returned invalid or missing total_xp data.");
-      }
-    } 
-    else {
-      try {
-        const { default: fetch } = await import('node-fetch');
-        const response = await fetch(`https://codestats.net/api/users/${encodeURIComponent(username)}`);
-        
-        if (!response.ok) {
-          // Handle specific HTTP error status codes
-          switch (response.status) {
-            case 404:
-              throw new Error(`Code::Stats API error (${response.status}): User '${username}' not found. Check your CODESTATS_USERNAME in config.`);
-            default:
-              throw new Error(`Code::Stats API server error (${response.status}): ${response.statusText}`);
-          }
-        }
-        
-        const data = await response.json();
-        
-        if (data && typeof data.total_xp === 'number') {
-          const result = {
-            codestatsXP: data.total_xp.toString()
-          };
-
-          // Cache the successful API response
-          codestatsCache.data = result;
-          codestatsCache.expiresAt = Date.now() + config.cache.CODESTATS_CACHE_TTL_MS;
-          console.info('Code::Stats data fetched from API and cached.');
-          
-          return result;
-        } else {
-          throw new Error("Code::Stats API returned invalid or missing total_xp data.");
-        }
-      } catch (error) {
-        console.error('Error fetching Code::Stats data in Node environment:', error.message);
-        console.info('Using default Code::Stats data due to API error.');
-        return {
-          codestatsXP: config.apiDefaults.CODESTATS_XP
-        };
-      }
-    }
+    const result = ok({ codestatsXP: data.total_xp.toString() })
+    codestatsCache = { result, expiresAt: Date.now() + config.cache.CODESTATS_CACHE_TTL_MS }
+    return result
   } catch (error) {
-    console.error('Error fetching Code::Stats data:', error.message);
-    console.info('Using default Code::Stats data due to API error.');
-    return {
-      codestatsXP: config.apiDefaults.CODESTATS_XP
-    };
+    console.warn(`Code::Stats data unavailable, using default: ${error.message}`)
+    return fallback({ codestatsXP: config.apiDefaults.CODESTATS_XP }, error)
   }
 }
 
-export { getCodeStatsData };
+export { getCodeStatsData }

--- a/src/services/data_sources/spotifyDataSource.js
+++ b/src/services/data_sources/spotifyDataSource.js
@@ -1,120 +1,95 @@
 /**
  * spotifyDataSource.js
- * Responsible for fetching and caching Spotify track data
- * Single Responsibility: Spotify data acquisition
+ * Single Responsibility: Spotify track acquisition (currently / recently played)
+ *
+ * Returns a discriminated source result (see sourceResult.js). "Nothing playing"
+ * (204 / no item) is a SUCCESS (`ok` with the default track string) — the user
+ * simply isn't listening. Auth, rate-limit, server, and network failures return
+ * `fallback` carrying the default AND the error, so they are distinguishable.
+ *
+ * Spotify keeps a bespoke fetch (rather than fetchJson) because 204 is a valid,
+ * body-less success it must interpret — not an error.
  */
-import { config } from '../../config/config.js';
-import spotifyOAuthService from '../auth/spotifyOAuthService.js';
+import { config } from '../../config/config.js'
+import spotifyOAuthService from '../auth/spotifyOAuthService.js'
+import { ok, fallback } from '../utils/sourceResult.js'
 
-// Initialize module-level cache store
-let spotifyCache = { data: null, expiresAt: 0 };
+let spotifyCache = { result: null, expiresAt: 0 }
 
-/**
- * Fetch Spotify track data with robust error handling and caching
- * @returns {Promise<Object>} - Currently playing or recently played track info
- */
-async function getSpotifyData() {
+const nothingPlaying = () => ({ spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING })
+
+async function getSpotifyData(deps = {}) {
+  if (spotifyCache.result && Date.now() < spotifyCache.expiresAt) {
+    return spotifyCache.result
+  }
+
+  let token
   try {
-    // Check if valid cached data exists
-    if (spotifyCache.data && Date.now() < spotifyCache.expiresAt) {
-      console.info('Using cached Spotify data.');
-      return spotifyCache.data;
-    }
+    token = await spotifyOAuthService.getAccessToken()
+  } catch (authError) {
+    console.warn(`Spotify auth unavailable, using default: ${authError.message}`)
+    return fallback(nothingPlaying(), authError)
+  }
 
-    // Get access token from OAuth service
-    let token;
-    try {
-      token = await spotifyOAuthService.getAccessToken();
-    } catch (authError) {
-      console.info('Spotify authentication error:', authError.message);
-      return { spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING };
-    }
-
-    // Try to get currently playing track first
-    let trackData = null;
-    
-    if (typeof fetch === 'function') {
-      // Browser environment
-      trackData = await fetchSpotifyData(fetch, token);
-    } else {
-      // Node.js environment
-      try {
-        const { default: nodeFetch } = await import('node-fetch');
-        trackData = await fetchSpotifyData(nodeFetch, token);
-      } catch (error) {
-        console.error('Error importing node-fetch:', error.message);
-        return { spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING };
-      }
-    }
-
-    // Cache the successful API response
-    spotifyCache.data = trackData;
-    spotifyCache.expiresAt = Date.now() + config.cache.SPOTIFY_CACHE_TTL_MS;
-    console.info('Spotify data fetched from API and cached.');
-    
-    return trackData;
+  try {
+    const value = await fetchSpotifyTrack(token, deps)
+    const result = ok(value)
+    spotifyCache = { result, expiresAt: Date.now() + config.cache.SPOTIFY_CACHE_TTL_MS }
+    return result
   } catch (error) {
-    console.error('Error fetching Spotify data:', error.message);
-    console.info('Using default Spotify data due to API error.');
-    return { spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING };
+    console.warn(`Spotify data unavailable, using default: ${error.message}`)
+    return fallback(nothingPlaying(), error)
+  }
+}
+
+function classifyHardError(status) {
+  if (status === 401 || status === 403 || status === 429 || status >= 500) {
+    const err = new Error(`Spotify API error (${status})`)
+    err.status = status // carried into the source result so PR-5b can flag 401/403/429
+    throw err
   }
 }
 
 /**
- * Helper function to fetch Spotify data using provided fetch implementation
- * @param {Function} fetchFn - Fetch function to use
- * @param {string} token - Spotify Bearer token
- * @returns {Promise<Object>} - Processed Spotify data
+ * Resolve the track to display. Returns { spotifyTrack }. Throws on hard errors
+ * (auth/rate-limit/server/network) so the caller can classify them as fallback.
+ * @param {string} token
+ * @param {{ fetchImpl?: typeof fetch }} [deps]
  */
-async function fetchSpotifyData(fetchFn, token) {
-  // Try currently playing endpoint
-  try {
-    const response = await fetchFn('https://api.spotify.com/v1/me/player/currently-playing', {
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
-    
-    if (response.status === 200) {
-      const data = await response.json();
-      if (data && data.item) {
-        const trackName = data.item.name;
-        const artistName = data.item.artists[0].name;
-        return { spotifyTrack: `${trackName} by ${artistName}` };
-      }
-    } else if (response.status === 204) {
-      // 204 means no content (not currently playing) - try recently played instead
-      console.info('Not currently playing any tracks. Checking recently played...');
-    } else if (response.status === 401) {
-      console.error('Spotify API error (401): Unauthorized. Your token may be invalid or expired.');
-      return { spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING };
-    } else if (response.status === 429) {
-      console.error('Spotify API error (429): Rate limit exceeded.');
-      return { spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING };
-    } else {
-      console.error(`Spotify API error (${response.status}): ${response.statusText}`);
-      return { spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING };
-    }
-    
-    // Fallback to recently played if not currently playing
-    const recentResponse = await fetchFn('https://api.spotify.com/v1/me/player/recently-played?limit=1', {
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
-    
-    if (recentResponse.status === 200) {
-      const recentData = await recentResponse.json();
-      if (recentData && recentData.items && recentData.items.length > 0) {
-        const track = recentData.items[0].track;
-        const trackName = track.name;
-        const artistName = track.artists[0].name;
-        return { spotifyTrack: `${trackName} by ${artistName}` };
-      }
-    }
-    
-    // If we get here, no current or recent tracks were found
-    return { spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING };
-  } catch (error) {
-    console.error('Error in Spotify API request:', error.message);
-    return { spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING };
+async function fetchSpotifyTrack(token, deps = {}) {
+  const fetchImpl = deps.fetchImpl || (typeof fetch === 'function' ? fetch : undefined)
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('No fetch implementation available')
   }
+  const headers = { Authorization: `Bearer ${token}` }
+
+  const current = await fetchImpl('https://api.spotify.com/v1/me/player/currently-playing', {
+    headers,
+  })
+  if (current.status === 200) {
+    const data = await current.json()
+    if (data && data.item) {
+      return { spotifyTrack: `${data.item.name} by ${data.item.artists[0].name}` }
+    }
+  } else if (current.status !== 204) {
+    classifyHardError(current.status)
+  }
+
+  const recent = await fetchImpl('https://api.spotify.com/v1/me/player/recently-played?limit=1', {
+    headers,
+  })
+  if (recent.status === 200) {
+    const recentData = await recent.json()
+    if (recentData && recentData.items && recentData.items.length > 0) {
+      const track = recentData.items[0].track
+      return { spotifyTrack: `${track.name} by ${track.artists[0].name}` }
+    }
+  } else {
+    classifyHardError(recent.status)
+  }
+
+  // Nothing currently or recently playing — a successful "not listening" state.
+  return nothingPlaying()
 }
 
-export { getSpotifyData };
+export { getSpotifyData }

--- a/src/services/data_sources/twitterDataSource.js
+++ b/src/services/data_sources/twitterDataSource.js
@@ -1,76 +1,49 @@
 /**
  * twitterDataSource.js
- * Responsible for fetching and caching Twitter/X follower count
- * Single Responsibility: Twitter data acquisition
+ * Single Responsibility: Twitter/X follower count acquisition
+ *
+ * Returns a discriminated source result (see sourceResult.js). Twitter is
+ * normally manual: when API fetch is disabled, the username is unset, or no
+ * bearer token is present, this returns `ok({})` — an intentional skip (the
+ * manual follower count is used downstream), NOT a failure. A configured fetch
+ * that fails returns `fallback` with the default AND the error.
  */
 import { config } from '../../config/config.js'
+import { fetchJson } from '../utils/httpClient.js'
+import { ok, fallback } from '../utils/sourceResult.js'
 
-// Module‑level cache
-let twitterCache = { data: null, expiresAt: 0 }
+let twitterCache = { result: null, expiresAt: 0 }
 
-/**
- * Fetch Twitter follower count with robust error‑handling & caching
- * @returns {Promise<{twitterFollowers:string}>}
- */
-export async function getTwitterData () {
+export async function getTwitterData(deps = {}) {
+  if (!config.twitter.enabled_api_fetch) return ok({})
+
+  const username = config.profile.TWITTER_USERNAME
+  if (!username) return ok({})
+
+  const token = process.env.TWITTER_BEARER_TOKEN
+  if (!token) return ok({})
+
+  if (twitterCache.result && Date.now() < twitterCache.expiresAt) {
+    return twitterCache.result
+  }
+
   try {
-    // First check if API fetching is enabled
-    if (!config.twitter.enabled_api_fetch) {
-      console.info('Twitter API fetch is disabled. Manual follower count will be used.')
-      return {}
-    }
-
-    const username = config.profile.TWITTER_USERNAME
-    if (!username) {
-      console.info('Twitter username not configured – skipping Twitter call.')
-      return {}
-    }
-
-    // serve from cache when fresh
-    if (twitterCache.data && Date.now() < twitterCache.expiresAt) {
-      console.info('Using cached Twitter data.')
-      return twitterCache.data
-    }
-
-    const token = process.env.TWITTER_BEARER_TOKEN
-    if (!token) {
-      console.info('Twitter API fetch enabled but TWITTER_BEARER_TOKEN is missing. Manual follower count will be used.')
-      return {}
-    }
-
-    const endpoint = `https://api.twitter.com/2/users/by/username/${encodeURIComponent(username)}?user.fields=public_metrics`
-    const fetchImpl = typeof fetch === 'function' ? fetch : (await import('node-fetch')).default
-
-    const res = await fetchImpl(endpoint, {
-      headers: { Authorization: `Bearer ${token}` }
+    const endpoint = `https://api.twitter.com/2/users/by/username/${encodeURIComponent(
+      username
+    )}?user.fields=public_metrics`
+    const json = await fetchJson(endpoint, {
+      headers: { Authorization: `Bearer ${token}` },
+      ...deps,
     })
-
-    if (!res.ok) {
-      switch (res.status) {
-        case 401: throw new Error('Unauthorized – invalid bearer token.')
-        case 403: throw new Error('Forbidden – check app permissions.')
-        case 404: throw new Error(`User "${username}" not found.`)
-        case 429: throw new Error('Rate‑limit exceeded.')
-        default:  throw new Error(`Twitter API ${res.status}: ${res.statusText}`)
-      }
-    }
-
-    const json = await res.json()
     const count = json?.data?.public_metrics?.followers_count
-    if (typeof count !== 'number') throw new Error('Twitter API returned invalid follower count.')
-
-    const result = { twitterFollowers: count.toString() }
-
-    // cache & return
-    twitterCache = {
-      data: result,
-      expiresAt: Date.now() + config.cache.TWITTER_CACHE_TTL_MS
+    if (typeof count !== 'number') {
+      throw new Error('Twitter API returned invalid follower count.')
     }
-    console.info('Twitter data fetched & cached.')
+    const result = ok({ twitterFollowers: count.toString() })
+    twitterCache = { result, expiresAt: Date.now() + config.cache.TWITTER_CACHE_TTL_MS }
     return result
   } catch (err) {
-    console.error('Error fetching Twitter data:', err.message)
-    console.info('Using default follower count.')
-    return { twitterFollowers: config.apiDefaults.TWITTER_FOLLOWERS }
+    console.warn(`Twitter data unavailable, using default follower count: ${err.message}`)
+    return fallback({ twitterFollowers: config.apiDefaults.TWITTER_FOLLOWERS }, err)
   }
 }

--- a/src/services/data_sources/wakatimeDataSource.js
+++ b/src/services/data_sources/wakatimeDataSource.js
@@ -1,195 +1,65 @@
 /**
  * wakatimeDataSource.js
- * Responsible for fetching and caching WakaTime coding activity data
- * Single Responsibility: WakaTime data acquisition
+ * Single Responsibility: WakaTime coding activity acquisition
+ *
+ * Returns a discriminated source result (see sourceResult.js): `ok` with live
+ * values (or `ok({})` when WakaTime is disabled — an intentional skip), or
+ * `fallback` carrying defaults AND the error.
  */
-import { config } from '../../config/config.js';
-import { getLanguageColor } from '../utils/languageColors.js';
+import { config } from '../../config/config.js'
+import { getLanguageColor } from '../utils/languageColors.js'
+import { fetchJson } from '../utils/httpClient.js'
+import { ok, fallback } from '../utils/sourceResult.js'
 
-// Initialize module-level cache store
-let wakatimeCache = { data: null, expiresAt: 0 };
+let wakatimeCache = { result: null, expiresAt: 0 }
 
-/**
- * Fetch WakaTime coding activity data with robust error handling and caching
- * @returns {Promise<Object>} - Coding activity data
- */
-async function getWakaTimeData() {
+async function getWakaTimeData(deps = {}) {
+  if (!config.wakatime.enabled) return ok({})
+  if (wakatimeCache.result && Date.now() < wakatimeCache.expiresAt) return wakatimeCache.result
+
+  const apiKey = process.env.WAKATIME_API_KEY
+  const username = config.profile.WAKATIME_USERNAME
+  if (!apiKey || !username) {
+    // Enabled but misconfigured → a real failure (distinct from disabled skip).
+    return fallback(
+      config.wakatime.defaults,
+      new Error('WakaTime enabled but API key or username is not configured.')
+    )
+  }
+
   try {
-    // Check if WakaTime integration is enabled
-    if (!config.wakatime.enabled) {
-      console.info('WakaTime integration is disabled.');
-      return {};
+    const authHeader = 'Basic ' + Buffer.from(apiKey).toString('base64')
+    const data = await fetchJson(
+      `https://wakatime.com/api/v1/users/${username}/stats/last_7_days`,
+      { headers: { Authorization: authHeader, Accept: 'application/json' }, ...deps }
+    )
+    if (!data || !data.data) {
+      throw new Error('WakaTime API returned empty or invalid data.')
     }
-    
-    // Check if valid cached data exists
-    if (wakatimeCache.data && Date.now() < wakatimeCache.expiresAt) {
-      console.info('Using cached WakaTime data.');
-      return wakatimeCache.data;
+    const stats = data.data
+    const result = {
+      wakatime_summary: `Coded for ${stats.human_readable_total_including_other_language || '0 hrs'} in the last week`,
+      wakatime_top_language: 'None',
+      wakatime_top_language_percent: '0',
+      wakatime_chart_data: [],
     }
-
-    // Get API key from environment variables
-    const apiKey = process.env.WAKATIME_API_KEY;
-    if (!apiKey) {
-      throw new Error("WakaTime API key not provided in environment variables.");
+    if (stats.languages && stats.languages.length > 0) {
+      const topLang = stats.languages[0]
+      result.wakatime_top_language = topLang.name
+      result.wakatime_top_language_percent = Math.round(topLang.percent).toString()
+      result.wakatime_chart_data = stats.languages.slice(0, 5).map((lang) => ({
+        label: lang.name,
+        value: Math.round(lang.percent),
+        color: getLanguageColor(lang.name),
+      }))
     }
-
-    // Get username from config
-    const username = config.profile.WAKATIME_USERNAME;
-    if (!username) {
-      throw new Error("WakaTime username not configured.");
-    }
-
-    // For browser environments
-    if (typeof fetch === 'function') {
-      // Use browser's btoa() for base64 encoding in browser environments
-      const authHeader = 'Basic ' + btoa(apiKey);
-      
-      // Fetch data from WakaTime API for the last 7 days
-      const response = await fetch(
-        `https://wakatime.com/api/v1/users/${username}/stats/last_7_days`,
-        {
-          headers: {
-            'Authorization': authHeader,
-            'Accept': 'application/json'
-          }
-        }
-      );
-      
-      if (!response.ok) {
-        // Handle specific HTTP error status codes
-        switch (response.status) {
-          case 401:
-            throw new Error(`WakaTime API error (${response.status}): Unauthorized. Your WAKATIME_API_KEY may be invalid.`);
-          case 403:
-            throw new Error(`WakaTime API error (${response.status}): Forbidden. Check your API key permissions.`);
-          case 404:
-            throw new Error(`WakaTime API error (${response.status}): User '${username}' not found. Check your WAKATIME_USERNAME in config.`);
-          case 429:
-            throw new Error(`WakaTime API error (${response.status}): Rate limit exceeded.`);
-          default:
-            throw new Error(`WakaTime API server error (${response.status}): ${response.statusText}`);
-        }
-      }
-      
-      const data = await response.json();
-      
-      if (data && data.data) {
-        const stats = data.data;
-        
-        // Extract important data from the response
-        let result = {
-          wakatime_summary: `Coded for ${stats.human_readable_total_including_other_language || "0 hrs"} in the last week`,
-          wakatime_top_language: "None",
-          wakatime_top_language_percent: "0",
-          wakatime_chart_data: []
-        };
-        
-        // Extract top language data if available
-        if (stats.languages && stats.languages.length > 0) {
-          const topLang = stats.languages[0];
-          result.wakatime_top_language = topLang.name;
-          result.wakatime_top_language_percent = Math.round(topLang.percent).toString();
-          
-          // Format data for chart rendering (top 5 languages)
-          result.wakatime_chart_data = stats.languages.slice(0, 5).map(lang => ({
-            label: lang.name,
-            value: Math.round(lang.percent),
-            color: getLanguageColor(lang.name) // Using imported helper
-          }));
-        }
-
-        // Cache the successful API response
-        wakatimeCache.data = result;
-        wakatimeCache.expiresAt = Date.now() + config.wakatime.cacheTtlMs;
-        console.info('WakaTime data fetched from API and cached.');
-        
-        return result;
-      } else {
-        throw new Error("WakaTime API returned empty or invalid data.");
-      }
-    } 
-    else {
-      // Node.js environment - try with node-fetch
-      try {
-        const { default: fetch } = await import('node-fetch');
-        
-        // Use Node.js Buffer for base64 encoding in Node environments
-        const authHeader = 'Basic ' + Buffer.from(apiKey).toString('base64');
-        
-        // Fetch data from WakaTime API for the last 7 days
-        const response = await fetch(
-          `https://wakatime.com/api/v1/users/${username}/stats/last_7_days`,
-          {
-            headers: {
-              'Authorization': authHeader,
-              'Accept': 'application/json'
-            }
-          }
-        );
-        
-        if (!response.ok) {
-          // Handle specific HTTP error status codes
-          switch (response.status) {
-            case 401:
-              throw new Error(`WakaTime API error (${response.status}): Unauthorized. Your WAKATIME_API_KEY may be invalid.`);
-            case 403:
-              throw new Error(`WakaTime API error (${response.status}): Forbidden. Check your API key permissions.`);
-            case 404:
-              throw new Error(`WakaTime API error (${response.status}): User '${username}' not found. Check your WAKATIME_USERNAME in config.`);
-            case 429:
-              throw new Error(`WakaTime API error (${response.status}): Rate limit exceeded.`);
-            default:
-              throw new Error(`WakaTime API server error (${response.status}): ${response.statusText}`);
-          }
-        }
-        
-        const data = await response.json();
-        
-        if (data && data.data) {
-          const stats = data.data;
-          
-          // Extract important data from the response
-          let result = {
-            wakatime_summary: `Coded for ${stats.human_readable_total_including_other_language || "0 hrs"} in the last week`,
-            wakatime_top_language: "None",
-            wakatime_top_language_percent: "0",
-            wakatime_chart_data: []
-          };
-          
-          // Extract top language data if available
-          if (stats.languages && stats.languages.length > 0) {
-            const topLang = stats.languages[0];
-            result.wakatime_top_language = topLang.name;
-            result.wakatime_top_language_percent = Math.round(topLang.percent).toString();
-            
-            // Format data for chart rendering (top 5 languages)
-            result.wakatime_chart_data = stats.languages.slice(0, 5).map(lang => ({
-              label: lang.name,
-              value: Math.round(lang.percent),
-              color: getLanguageColor(lang.name) // Using imported helper
-            }));
-          }
-
-          // Cache the successful API response
-          wakatimeCache.data = result;
-          wakatimeCache.expiresAt = Date.now() + config.wakatime.cacheTtlMs;
-          console.info('WakaTime data fetched from API and cached.');
-          
-          return result;
-        } else {
-          throw new Error("WakaTime API returned empty or invalid data.");
-        }
-      } catch (error) {
-        console.error('Error fetching WakaTime data in Node environment:', error.message);
-        console.info('Using default WakaTime data due to API error.');
-        return config.wakatime.defaults;
-      }
-    }
+    const okResult = ok(result)
+    wakatimeCache = { result: okResult, expiresAt: Date.now() + config.wakatime.cacheTtlMs }
+    return okResult
   } catch (error) {
-    console.error('Error fetching WakaTime data:', error.message);
-    console.info('Using default WakaTime data due to API error.');
-    return config.wakatime.defaults;
+    console.warn(`WakaTime data unavailable, using defaults: ${error.message}`)
+    return fallback(config.wakatime.defaults, error)
   }
 }
 
-export { getWakaTimeData };
+export { getWakaTimeData }

--- a/src/services/data_sources/weatherDataSource.js
+++ b/src/services/data_sources/weatherDataSource.js
@@ -1,12 +1,16 @@
 /**
  * weatherDataSource.js
- * Responsible for fetching and caching weather data
- * Single Responsibility: Weather data acquisition
+ * Single Responsibility: Weather data acquisition (AccuWeather)
+ *
+ * Returns a discriminated source result (see sourceResult.js): `ok` with live
+ * values (or `ok({})` when weather is disabled / not configured — an intentional
+ * skip, not a failure), or `fallback` carrying defaults AND the error.
  */
-import { config } from '../../config/config.js';
+import { config } from '../../config/config.js'
+import { fetchJson } from '../utils/httpClient.js'
+import { ok, fallback } from '../utils/sourceResult.js'
 
-// Initialize module-level cache store
-let weatherCache = { data: null, expiresAt: 0 };
+let weatherCache = { result: null, expiresAt: 0 }
 
 /**
  * Maps weather conditions to appropriate emojis
@@ -19,170 +23,70 @@ function getWeatherEmoji(weatherText) {
     'partly sunny': '⛅',
     'mostly cloudy': '🌥️',
     'partly cloudy': '⛅',
-    'sunny': '☀️',
-    'clear': '☀️',
-    'cloudy': '☁️',
-    'rain': '🌧️',
-    'showers': '🌦️',
-    'thunderstorm': '⛈️',
-    'snow': '❄️',
-    'ice': '🧊',
-    'fog': '🌫️',
-    'windy': '💨'
-  };
+    sunny: '☀️',
+    clear: '☀️',
+    cloudy: '☁️',
+    rain: '🌧️',
+    showers: '🌦️',
+    thunderstorm: '⛈️',
+    snow: '❄️',
+    ice: '🧊',
+    fog: '🌫️',
+    windy: '💨',
+  }
 
-  if (!weatherText) return config.apiDefaults.WEATHER_EMOJI;
-  
-  const lowerWeatherText = weatherText.toLowerCase();
-  
-  let bestMatch = '';
-  let bestEmoji = config.apiDefaults.WEATHER_EMOJI;
-  
+  if (!weatherText) return config.apiDefaults.WEATHER_EMOJI
+
+  const lowerWeatherText = weatherText.toLowerCase()
+  let bestMatch = ''
+  let bestEmoji = config.apiDefaults.WEATHER_EMOJI
+
   for (const [condition, emoji] of Object.entries(weatherMap)) {
     if (lowerWeatherText.includes(condition) && condition.length > bestMatch.length) {
-      bestMatch = condition;
-      bestEmoji = emoji;
+      bestMatch = condition
+      bestEmoji = emoji
     }
   }
-  
-  return bestEmoji;
+  return bestEmoji
 }
 
-/**
- * Fetch weather data from AccuWeather API with robust error handling and caching
- * @returns {Promise<Object>} - Weather data (temperature, description, emoji)
- */
-async function getWeatherData() {
+async function getWeatherData(deps = {}) {
+  // Disabled or not configured → intentional skip (no failure to flag).
+  if (!config.weather.enabled) return ok({})
+  if (weatherCache.result && Date.now() < weatherCache.expiresAt) return weatherCache.result
+
+  const apiKey = process.env.WEATHER_API_KEY
+  const locationKey = process.env.LOCATION_KEY
+  if (!apiKey || !locationKey) return ok({})
+
+  const defaults = {
+    temperature: config.apiDefaults.TEMPERATURE,
+    weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
+    emoji: config.apiDefaults.WEATHER_EMOJI,
+  }
+
   try {
-    // Check if weather integration is disabled via configuration
-    if (!config.weather.enabled) {
-      console.info('Weather data fetching is disabled via configuration.');
-      return {};
+    const data = await fetchJson(
+      `https://dataservice.accuweather.com/currentconditions/v1/${locationKey}?apikey=${apiKey}`,
+      { ...deps }
+    )
+    if (!data || data.length === 0) {
+      throw new Error('AccuWeather API returned empty data.')
     }
-
-    // Check if valid cached data exists
-    if (weatherCache.data && Date.now() < weatherCache.expiresAt) {
-      console.info('Using cached weather data.');
-      return weatherCache.data;
-    }
-
-    // Get API key and location key from environment variables
-    const apiKey = process.env.WEATHER_API_KEY;
-    const locationKey = process.env.LOCATION_KEY;
-    
-    if (!apiKey || !locationKey) {
-      console.info('Weather API key or location key not provided, skipping weather fetch.');
-      return {};
-    }
-    
-    // For browser environments
-    if (typeof fetch === 'function') {
-      const response = await fetch(
-        `https://dataservice.accuweather.com/currentconditions/v1/${locationKey}?apikey=${apiKey}`
-      );
-      
-      if (!response.ok) {
-        // Handle specific HTTP error status codes
-        switch (response.status) {
-          case 401:
-            throw new Error(`AccuWeather API error (${response.status}): Unauthorized. Your WEATHER_API_KEY may be invalid.`);
-          case 400:
-          case 403:
-            throw new Error(`AccuWeather API error (${response.status}): Bad request or forbidden. Check your LOCATION_KEY and API key permissions.`);
-          case 429:
-            throw new Error(`AccuWeather API error (${response.status}): Rate limit exceeded. You may have reached your AccuWeather API quota.`);
-          default:
-            throw new Error(`AccuWeather API server error (${response.status}): ${response.statusText}`);
-        }
-      }
-      
-      const data = await response.json();
-      
-      if (data && data.length > 0) {
-        const weatherData = data[0];
-        const tempF = weatherData.Temperature.Imperial.Value;
-        const tempC = Math.round((tempF - 32) * 5 / 9);
-        
-        const result = {
-          temperature: `${tempF}°F (${tempC}°C)`,
-          weatherDescription: weatherData.WeatherText.toLowerCase(),
-          emoji: getWeatherEmoji(weatherData.WeatherText)
-        };
-
-        // Cache the successful API response
-        weatherCache.data = result;
-        weatherCache.expiresAt = Date.now() + config.cache.WEATHER_CACHE_TTL_MS;
-        console.info('Weather data fetched from API and cached.');
-        
-        return result;
-      } else {
-        throw new Error("AccuWeather API returned empty data.");
-      }
-    } 
-    else {
-      // Node.js environment - try with node-fetch
-      try {
-        const { default: fetch } = await import('node-fetch');
-        const response = await fetch(
-          `https://dataservice.accuweather.com/currentconditions/v1/${locationKey}?apikey=${apiKey}`
-        );
-        
-        if (!response.ok) {
-          // Handle specific HTTP error status codes
-          switch (response.status) {
-            case 401:
-              throw new Error(`AccuWeather API error (${response.status}): Unauthorized. Your WEATHER_API_KEY may be invalid.`);
-            case 400:
-            case 403:
-              throw new Error(`AccuWeather API error (${response.status}): Bad request or forbidden. Check your LOCATION_KEY and API key permissions.`);
-            case 429:
-              throw new Error(`AccuWeather API error (${response.status}): Rate limit exceeded. You may have reached your AccuWeather API quota.`);
-            default:
-              throw new Error(`AccuWeather API server error (${response.status}): ${response.statusText}`);
-          }
-        }
-        
-        const data = await response.json();
-        
-        if (data && data.length > 0) {
-          const weatherData = data[0];
-          const tempF = weatherData.Temperature.Imperial.Value;
-          const tempC = Math.round((tempF - 32) * 5 / 9);
-          
-          const result = {
-            temperature: `${tempF}°F (${tempC}°C)`,
-            weatherDescription: weatherData.WeatherText.toLowerCase(),
-            emoji: getWeatherEmoji(weatherData.WeatherText)
-          };
-
-          // Cache the successful API response
-          weatherCache.data = result;
-          weatherCache.expiresAt = Date.now() + config.cache.WEATHER_CACHE_TTL_MS;
-          console.info('Weather data fetched from API and cached.');
-          
-          return result;
-        } else {
-          throw new Error("AccuWeather API returned empty data.");
-        }
-      } catch (error) {
-        console.error('Error fetching AccuWeather data in Node environment:', error.message);
-        console.info('Using default weather data due to API error.');
-        return {
-          temperature: config.apiDefaults.TEMPERATURE,
-          weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
-          emoji: config.apiDefaults.WEATHER_EMOJI
-        };
-      }
-    }
+    const weatherData = data[0]
+    const tempF = weatherData.Temperature.Imperial.Value
+    const tempC = Math.round(((tempF - 32) * 5) / 9)
+    const result = ok({
+      temperature: `${tempF}°F (${tempC}°C)`,
+      weatherDescription: weatherData.WeatherText.toLowerCase(),
+      emoji: getWeatherEmoji(weatherData.WeatherText),
+    })
+    weatherCache = { result, expiresAt: Date.now() + config.cache.WEATHER_CACHE_TTL_MS }
+    return result
   } catch (error) {
-    console.error('Error fetching AccuWeather data:', error.message);
-    console.info('Using default weather data due to API error.');
-    return {
-      temperature: config.apiDefaults.TEMPERATURE,
-      weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
-      emoji: config.apiDefaults.WEATHER_EMOJI
-    };
+    console.warn(`Weather data unavailable, using defaults: ${error.message}`)
+    return fallback(defaults, error)
   }
 }
 
-export { getWeatherData };
+export { getWeatherData }

--- a/tests/integration/__tests__/ProfileChatter.integration.test.js
+++ b/tests/integration/__tests__/ProfileChatter.integration.test.js
@@ -375,9 +375,8 @@ describe('ProfileChatter Integration Tests', () => {
 
       // Mock all data source functions to return their default values
       getWeatherData.mockResolvedValue({
-        temperature: '72°F (22°C)',
-        weatherDescription: 'partly cloudy',
-        emoji: '⛅',
+        status: 'ok',
+        value: { temperature: '72°F (22°C)', weatherDescription: 'partly cloudy', emoji: '⛅' },
       })
 
       getGitHubData.mockResolvedValue({
@@ -386,22 +385,22 @@ describe('ProfileChatter Integration Tests', () => {
       })
 
       getSpotifyData.mockResolvedValue({
-        spotifyTrack: 'Not currently listening to music.',
+        status: 'ok',
+        value: { spotifyTrack: 'Not currently listening to music.' },
       })
 
       getWakaTimeData.mockResolvedValue({
-        wakatime_summary: 'No coding activity data available',
-        wakatime_top_language: 'N/A',
-        wakatime_top_language_percent: '0',
+        status: 'ok',
+        value: {
+          wakatime_summary: 'No coding activity data available',
+          wakatime_top_language: 'N/A',
+          wakatime_top_language_percent: '0',
+        },
       })
 
-      getTwitterData.mockResolvedValue({
-        twitterFollowers: '120',
-      })
+      getTwitterData.mockResolvedValue({ status: 'ok', value: { twitterFollowers: '120' } })
 
-      getCodeStatsData.mockResolvedValue({
-        codestatsXP: '0',
-      })
+      getCodeStatsData.mockResolvedValue({ status: 'ok', value: { codestatsXP: '0' } })
 
       getGitHubOAuthData.mockResolvedValue({
         status: 'ok',
@@ -444,9 +443,8 @@ describe('ProfileChatter Integration Tests', () => {
 
       // Mock each data source function to return specific, non-default data
       getWeatherData.mockResolvedValue({
-        temperature: '75F Test',
-        weatherDescription: 'testing clouds',
-        emoji: '🧪',
+        status: 'ok',
+        value: { temperature: '75F Test', weatherDescription: 'testing clouds', emoji: '🧪' },
       })
 
       getGitHubData.mockResolvedValue({
@@ -455,22 +453,22 @@ describe('ProfileChatter Integration Tests', () => {
       })
 
       getSpotifyData.mockResolvedValue({
-        spotifyTrack: 'Test Song by Test Artist',
+        status: 'ok',
+        value: { spotifyTrack: 'Test Song by Test Artist' },
       })
 
       getWakaTimeData.mockResolvedValue({
-        wakatime_summary: 'Coded for 40 hrs in the last week',
-        wakatime_top_language: 'JavaScript',
-        wakatime_top_language_percent: '65',
+        status: 'ok',
+        value: {
+          wakatime_summary: 'Coded for 40 hrs in the last week',
+          wakatime_top_language: 'JavaScript',
+          wakatime_top_language_percent: '65',
+        },
       })
 
-      getTwitterData.mockResolvedValue({
-        twitterFollowers: '500',
-      })
+      getTwitterData.mockResolvedValue({ status: 'ok', value: { twitterFollowers: '500' } })
 
-      getCodeStatsData.mockResolvedValue({
-        codestatsXP: '15000',
-      })
+      getCodeStatsData.mockResolvedValue({ status: 'ok', value: { codestatsXP: '15000' } })
 
       getGitHubOAuthData.mockResolvedValue({
         status: 'ok',
@@ -552,22 +550,22 @@ describe('ProfileChatter Integration Tests', () => {
       })
 
       getSpotifyData.mockResolvedValue({
-        spotifyTrack: 'Working Song by Developer',
+        status: 'ok',
+        value: { spotifyTrack: 'Working Song by Developer' },
       })
 
       getWakaTimeData.mockResolvedValue({
-        wakatime_summary: 'Coded for 30 hrs in the last week',
-        wakatime_top_language: 'Python',
-        wakatime_top_language_percent: '50',
+        status: 'ok',
+        value: {
+          wakatime_summary: 'Coded for 30 hrs in the last week',
+          wakatime_top_language: 'Python',
+          wakatime_top_language_percent: '50',
+        },
       })
 
-      getTwitterData.mockResolvedValue({
-        twitterFollowers: '200',
-      })
+      getTwitterData.mockResolvedValue({ status: 'ok', value: { twitterFollowers: '200' } })
 
-      getCodeStatsData.mockResolvedValue({
-        codestatsXP: '8000',
-      })
+      getCodeStatsData.mockResolvedValue({ status: 'ok', value: { codestatsXP: '8000' } })
 
       getGitHubOAuthData.mockResolvedValue({
         status: 'ok',
@@ -612,12 +610,12 @@ describe('ProfileChatter Integration Tests', () => {
       validateConfiguration.mockReturnValue(false)
 
       // Mock data sources (they shouldn't be called due to early validation failure)
-      getWeatherData.mockResolvedValue({})
+      getWeatherData.mockResolvedValue({ status: 'ok', value: {} })
       getGitHubData.mockResolvedValue({ status: 'ok', value: {} })
-      getSpotifyData.mockResolvedValue({})
-      getWakaTimeData.mockResolvedValue({})
-      getTwitterData.mockResolvedValue({})
-      getCodeStatsData.mockResolvedValue({})
+      getSpotifyData.mockResolvedValue({ status: 'ok', value: {} })
+      getWakaTimeData.mockResolvedValue({ status: 'ok', value: {} })
+      getTwitterData.mockResolvedValue({ status: 'ok', value: {} })
+      getCodeStatsData.mockResolvedValue({ status: 'ok', value: {} })
       getGitHubOAuthData.mockResolvedValue({ status: 'ok', value: {} })
 
       const customContext = {

--- a/tests/unit/services/__tests__/DataService.test.js
+++ b/tests/unit/services/__tests__/DataService.test.js
@@ -130,11 +130,10 @@ describe('DataService', () => {
     })
 
     it('should successfully merge data from all API sources', async () => {
-      // Mock all data sources to return success data
+      // Mock all data sources to return success data (discriminated results)
       getWeatherData.mockResolvedValue({
-        temperature: '75°F (24°C)',
-        weatherDescription: 'partly cloudy',
-        emoji: '⛅',
+        status: 'ok',
+        value: { temperature: '75°F (24°C)', weatherDescription: 'partly cloudy', emoji: '⛅' },
       })
 
       getGitHubData.mockResolvedValue({
@@ -143,21 +142,21 @@ describe('DataService', () => {
       })
 
       getWakaTimeData.mockResolvedValue({
-        wakatime_summary: 'Coded for 8 hrs',
-        wakatime_top_language: 'JavaScript',
-        wakatime_top_language_percent: '65',
+        status: 'ok',
+        value: {
+          wakatime_summary: 'Coded for 8 hrs',
+          wakatime_top_language: 'JavaScript',
+          wakatime_top_language_percent: '65',
+        },
       })
 
-      getTwitterData.mockResolvedValue({
-        twitterFollowers: '150',
-      })
+      getTwitterData.mockResolvedValue({ status: 'ok', value: { twitterFollowers: '150' } })
 
-      getCodeStatsData.mockResolvedValue({
-        codestatsXP: '2500',
-      })
+      getCodeStatsData.mockResolvedValue({ status: 'ok', value: { codestatsXP: '2500' } })
 
       getSpotifyData.mockResolvedValue({
-        spotifyTrack: 'Test Song by Test Artist',
+        status: 'ok',
+        value: { spotifyTrack: 'Test Song by Test Artist' },
       })
 
       getGitHubOAuthData.mockResolvedValue({

--- a/tests/unit/services/data_sources/codestatsDataSource.test.js
+++ b/tests/unit/services/data_sources/codestatsDataSource.test.js
@@ -1,208 +1,74 @@
-// tests/unit/services/data_sources/codestatsDataSource.test.js - COMPLETELY FIXED
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// tests/unit/services/data_sources/codestatsDataSource.test.js
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-vi.mock('node-fetch', () => ({
-  default: vi.fn()
-}));
-
-// Mock the config module to control the username
 vi.mock('../../../../src/config/config.js', () => ({
   config: {
-    profile: {
-      CODESTATS_USERNAME: 'testuser' // Default test value
-    },
-    cache: {
-      CODESTATS_CACHE_TTL_MS: 7200000
-    },
-    apiDefaults: {
-      CODESTATS_XP: '0'
-    }
-  }
-}));
+    profile: { CODESTATS_USERNAME: 'u' },
+    cache: { CODESTATS_CACHE_TTL_MS: 7200000 },
+    apiDefaults: { CODESTATS_XP: '0' },
+  },
+}))
 
-describe('codestatsDataSource', () => {
-  let mockFetch;
-  let getCodeStatsData;
-  let config;
+let getCodeStatsData
+let config
+const noSleep = () => Promise.resolve()
+const okFetch = (body) =>
+  vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => body })
 
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.useFakeTimers();
-    
-    // Reset module to clear cache
-    vi.resetModules();
-    
-    // Import fresh modules
-    const configModule = await import('../../../../src/config/config.js');
-    config = configModule.config;
-    
-    // Set default test username
-    config.profile.CODESTATS_USERNAME = 'testuser';
-    
-    const module = await import('../../../../src/services/data_sources/codestatsDataSource.js');
-    getCodeStatsData = module.getCodeStatsData;
-    
-    mockFetch = vi.fn();
-    
-    if (typeof fetch === 'undefined') {
-      global.fetch = undefined;
-    }
-  });
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.resetModules()
+  config = (await import('../../../../src/config/config.js')).config
+  config.profile.CODESTATS_USERNAME = 'u' // reset shared mock (mutated by skip test)
+  ;({ getCodeStatsData } = await import(
+    '../../../../src/services/data_sources/codestatsDataSource.js'
+  ))
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    if (global.fetch === undefined) {
-      delete global.fetch;
-    }
-  });
+describe('codestatsDataSource — discriminated results', () => {
+  it('returns ok with the total XP', async () => {
+    const fetchImpl = okFetch({ total_xp: 12345 })
+    const r = await getCodeStatsData({ fetchImpl, sleep: noSleep })
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({ codestatsXP: '12345' })
+    expect(fetchImpl.mock.calls[0][0]).toBe('https://codestats.net/api/users/u')
+  })
 
-  describe('Configuration Checks', () => {
-    it('should skip API call when username not configured', async () => {
-      // Set empty username BEFORE calling the function
-      config.profile.CODESTATS_USERNAME = '';
-      global.fetch = mockFetch;
+  it('returns ok({}) (skip) when not configured', async () => {
+    config.profile.CODESTATS_USERNAME = undefined
+    const fetchImpl = vi.fn()
+    const r = await getCodeStatsData({ fetchImpl })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({})
+  })
 
-      const result = await getCodeStatsData();
+  it('returns a FALLBACK on a 404 (distinguishable, carries status)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    })
+    const r = await getCodeStatsData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.status).toBe('fallback')
+    expect(r.error.status).toBe(404)
+    expect(r.value).toEqual({ codestatsXP: '0' })
+  })
 
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({});
-    });
-  });
+  it('returns a FALLBACK on invalid/missing total_xp', async () => {
+    const r = await getCodeStatsData({ fetchImpl: okFetch({ nope: true }), sleep: noSleep })
+    expect(r.status).toBe('fallback')
+  })
 
-  describe('Successful API Fetch & Caching', () => {
-    it('should fetch CodeStats data successfully', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ total_xp: 123456 })
-      });
-
-      const result = await getCodeStatsData();
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://codestats.net/api/users/testuser'
-      );
-      expect(result).toEqual({ codestatsXP: '123456' });
-    });
-
-    it('should handle non-numeric XP gracefully', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ total_xp: null })
-      });
-
-      const result = await getCodeStatsData();
-
-      expect(result).toEqual({
-        codestatsXP: config.apiDefaults.CODESTATS_XP
-      });
-    });
-
-    it('should use cached data', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ total_xp: 99999 })
-      });
-
-      await getCodeStatsData();
-      const result = await getCodeStatsData();
-
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(result).toEqual({ codestatsXP: '99999' });
-    });
-
-    it('should refresh after cache expires', async () => {
-      global.fetch = mockFetch;
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ total_xp: 1000 })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ total_xp: 2000 })
-        });
-
-      await getCodeStatsData();
-      vi.advanceTimersByTime(config.cache.CODESTATS_CACHE_TTL_MS + 1000);
-      const result = await getCodeStatsData();
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(result).toEqual({ codestatsXP: '2000' });
-    });
-  });
-
-  describe('API Error Handling', () => {
-    it('should handle 404 user not found', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found'
-      });
-
-      const result = await getCodeStatsData();
-
-      expect(result).toEqual({
-        codestatsXP: config.apiDefaults.CODESTATS_XP
-      });
-    });
-
-    it('should handle server errors', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error'
-      });
-
-      const result = await getCodeStatsData();
-
-      expect(result).toEqual({
-        codestatsXP: config.apiDefaults.CODESTATS_XP
-      });
-    });
-
-    it('should handle network errors', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-      const result = await getCodeStatsData();
-
-      expect(result).toEqual({
-        codestatsXP: config.apiDefaults.CODESTATS_XP
-      });
-    });
-  });
-
-  describe('Node Environment', () => {
-    it('should work in Node environment', async () => {
-      delete global.fetch;
-      const nodeFetch = (await import('node-fetch')).default;
-      nodeFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ total_xp: 777777 })
-      });
-
-      const result = await getCodeStatsData();
-
-      expect(nodeFetch).toHaveBeenCalled();
-      expect(result).toEqual({ codestatsXP: '777777' });
-    });
-
-    it('should handle Node environment errors', async () => {
-      delete global.fetch;
-      const nodeFetch = (await import('node-fetch')).default;
-      nodeFetch.mockRejectedValueOnce(new Error('Node error'));
-
-      const result = await getCodeStatsData();
-
-      expect(result).toEqual({
-        codestatsXP: config.apiDefaults.CODESTATS_XP
-      });
-    });
-  });
-});
+  it('caches an ok result', async () => {
+    const fetchImpl = okFetch({ total_xp: 1 })
+    await getCodeStatsData({ fetchImpl, sleep: noSleep })
+    await getCodeStatsData({ fetchImpl, sleep: noSleep })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/services/data_sources/spotifyDataSource.test.js
+++ b/tests/unit/services/data_sources/spotifyDataSource.test.js
@@ -1,304 +1,87 @@
-// tests/unit/services/data_sources/spotifyDataSource.test.js - FIXED
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { config } from '../../../../src/config/config.js';
-import spotifyOAuthService from '../../../../src/services/auth/spotifyOAuthService.js';
+// tests/unit/services/data_sources/spotifyDataSource.test.js
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import spotifyOAuthService from '../../../../src/services/auth/spotifyOAuthService.js'
 
-vi.mock('node-fetch', () => ({
-  default: vi.fn()
-}));
+vi.mock('../../../../src/config/config.js', () => ({
+  config: {
+    cache: { SPOTIFY_CACHE_TTL_MS: 900000 },
+    apiDefaults: { SPOTIFY_NOW_PLAYING: 'Not listening' },
+  },
+}))
 
 vi.mock('../../../../src/services/auth/spotifyOAuthService.js', () => ({
-  default: {
-    getAccessToken: vi.fn()
-  }
-}));
+  default: { getAccessToken: vi.fn() },
+}))
 
-describe('spotifyDataSource', () => {
-  let mockFetch;
-  let getSpotifyData;
+let getSpotifyData
+const res = (status, body) => ({ status, json: async () => body })
 
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.useFakeTimers();
-    
-    // Reset module
-    vi.resetModules();
-    const module = await import('../../../../src/services/data_sources/spotifyDataSource.js');
-    getSpotifyData = module.getSpotifyData;
-    
-    mockFetch = vi.fn();
-    if (typeof fetch === 'undefined') {
-      global.fetch = undefined;
-    }
-  });
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.resetModules()
+  ;({ getSpotifyData } = await import('../../../../src/services/data_sources/spotifyDataSource.js'))
+  spotifyOAuthService.getAccessToken.mockResolvedValue('tok')
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    if (global.fetch === undefined) {
-      delete global.fetch;
-    }
-  });
+describe('spotifyDataSource — discriminated results', () => {
+  it('returns ok with the currently playing track', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(res(200, { item: { name: 'Song', artists: [{ name: 'Artist' }] } }))
+    const r = await getSpotifyData({ fetchImpl })
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({ spotifyTrack: 'Song by Artist' })
+  })
 
-  describe('Authentication', () => {
-    it('should handle authentication errors', async () => {
-      spotifyOAuthService.getAccessToken.mockRejectedValueOnce(
-        new Error('No valid token')
-      );
-      global.fetch = mockFetch;
+  it('falls through to recently played when nothing is currently playing (204)', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(res(204, {}))
+      .mockResolvedValueOnce(
+        res(200, { items: [{ track: { name: 'R', artists: [{ name: 'A' }] } }] })
+      )
+    const r = await getSpotifyData({ fetchImpl })
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({ spotifyTrack: 'R by A' })
+  })
 
-      const result = await getSpotifyData();
+  it('returns ok with the default "not listening" string when nothing is playing at all', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(res(204, {}))
+      .mockResolvedValueOnce(res(200, { items: [] }))
+    const r = await getSpotifyData({ fetchImpl })
+    expect(r.status).toBe('ok') // not listening is a SUCCESS, not a failure
+    expect(r.value).toEqual({ spotifyTrack: 'Not listening' })
+  })
 
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING
-      });
-    });
-  });
+  it('returns a FALLBACK on an auth failure', async () => {
+    spotifyOAuthService.getAccessToken.mockRejectedValueOnce(new Error('no token'))
+    const fetchImpl = vi.fn()
+    const r = await getSpotifyData({ fetchImpl })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(r.status).toBe('fallback')
+    expect(r.value).toEqual({ spotifyTrack: 'Not listening' })
+  })
 
-  describe('Successful API Fetch & Caching', () => {
-    it('should fetch currently playing track', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-      
-      mockFetch.mockResolvedValueOnce({
-        status: 200,
-        json: async () => ({
-          item: {
-            name: 'Test Song',
-            artists: [{ name: 'Test Artist' }]
-          }
-        })
-      });
+  it('returns a FALLBACK on a rate-limit (429) carrying the status', async () => {
+    const fetchImpl = vi.fn().mockResolvedValueOnce(res(429, {}))
+    const r = await getSpotifyData({ fetchImpl })
+    expect(r.status).toBe('fallback')
+    expect(r.error.status).toBe(429)
+  })
 
-      const result = await getSpotifyData();
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.spotify.com/v1/me/player/currently-playing',
-        { headers: { 'Authorization': 'Bearer test-token' } }
-      );
-      expect(result).toEqual({
-        spotifyTrack: 'Test Song by Test Artist'
-      });
-    });
-
-    it('should fallback to recently played when not currently playing', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-      
-      mockFetch
-        .mockResolvedValueOnce({ status: 204 }) // No content
-        .mockResolvedValueOnce({
-          status: 200,
-          json: async () => ({
-            items: [{
-              track: {
-                name: 'Recent Song',
-                artists: [{ name: 'Recent Artist' }]
-              }
-            }]
-          })
-        });
-
-      const result = await getSpotifyData();
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(mockFetch).toHaveBeenLastCalledWith(
-        'https://api.spotify.com/v1/me/player/recently-played?limit=1',
-        { headers: { 'Authorization': 'Bearer test-token' } }
-      );
-      expect(result).toEqual({
-        spotifyTrack: 'Recent Song by Recent Artist'
-      });
-    });
-
-    it('should handle no tracks available', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-      
-      mockFetch
-        .mockResolvedValueOnce({ status: 204 })
-        .mockResolvedValueOnce({
-          status: 200,
-          json: async () => ({ items: [] })
-        });
-
-      const result = await getSpotifyData();
-
-      expect(result).toEqual({
-        spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING
-      });
-    });
-
-    it('should use cached data', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-      
-      mockFetch.mockResolvedValueOnce({
-        status: 200,
-        json: async () => ({
-          item: {
-            name: 'Cached Song',
-            artists: [{ name: 'Cached Artist' }]
-          }
-        })
-      });
-
-      await getSpotifyData();
-      // Reset mock counts for clarity
-      spotifyOAuthService.getAccessToken.mockClear();
-      mockFetch.mockClear();
-      
-      const result = await getSpotifyData();
-
-      expect(spotifyOAuthService.getAccessToken).not.toHaveBeenCalled();
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({
-        spotifyTrack: 'Cached Song by Cached Artist'
-      });
-    });
-
-    it('should refresh after cache expires', async () => {
-      spotifyOAuthService.getAccessToken
-        .mockResolvedValueOnce('token1')
-        .mockResolvedValueOnce('token2');
-      global.fetch = mockFetch;
-      
-      mockFetch
-        .mockResolvedValueOnce({
-          status: 200,
-          json: async () => ({
-            item: {
-              name: 'Song 1',
-              artists: [{ name: 'Artist 1' }]
-            }
-          })
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          json: async () => ({
-            item: {
-              name: 'Song 2',
-              artists: [{ name: 'Artist 2' }]
-            }
-          })
-        });
-
-      await getSpotifyData();
-      vi.advanceTimersByTime(config.cache.SPOTIFY_CACHE_TTL_MS + 1000);
-      const result = await getSpotifyData();
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(result).toEqual({
-        spotifyTrack: 'Song 2 by Artist 2'
-      });
-    });
-  });
-
-  describe('API Error Handling', () => {
-    it('should handle 401 Unauthorized', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-      
-      mockFetch.mockResolvedValueOnce({
-        status: 401,
-        statusText: 'Unauthorized'
-      });
-
-      const result = await getSpotifyData();
-
-      expect(result).toEqual({
-        spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING
-      });
-    });
-
-    it('should handle 429 Rate Limit', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-      
-      mockFetch.mockResolvedValueOnce({
-        status: 429,
-        statusText: 'Too Many Requests'
-      });
-
-      const result = await getSpotifyData();
-
-      expect(result).toEqual({
-        spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING
-      });
-    });
-
-    it('should handle generic API errors', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-      
-      mockFetch.mockResolvedValueOnce({
-        status: 500,
-        statusText: 'Internal Server Error'
-      });
-
-      const result = await getSpotifyData();
-
-      expect(result).toEqual({
-        spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING
-      });
-    });
-
-    it('should handle network errors', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      global.fetch = mockFetch;
-      
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-      const result = await getSpotifyData();
-
-      expect(result).toEqual({
-        spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING
-      });
-    });
-  });
-
-  describe('Node Environment', () => {
-    it('should use node-fetch in Node', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      delete global.fetch;
-      
-      const nodeFetch = (await import('node-fetch')).default;
-      nodeFetch.mockResolvedValueOnce({
-        status: 200,
-        json: async () => ({
-          item: {
-            name: 'Node Song',
-            artists: [{ name: 'Node Artist' }]
-          }
-        })
-      });
-
-      const result = await getSpotifyData();
-
-      expect(nodeFetch).toHaveBeenCalled();
-      expect(result).toEqual({
-        spotifyTrack: 'Node Song by Node Artist'
-      });
-    });
-
-    it('should handle Node import errors', async () => {
-      spotifyOAuthService.getAccessToken.mockResolvedValueOnce('test-token');
-      delete global.fetch;
-      
-      // Mock the dynamic import to throw
-      vi.doMock('node-fetch', () => {
-        throw new Error('Import failed');
-      });
-
-      const result = await getSpotifyData();
-
-      expect(result).toEqual({
-        spotifyTrack: config.apiDefaults.SPOTIFY_NOW_PLAYING
-      });
-      
-      // Clean up the mock
-      vi.doUnmock('node-fetch');
-    });
-  });
-});
+  it('caches an ok result', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(res(200, { item: { name: 'S', artists: [{ name: 'A' }] } }))
+    await getSpotifyData({ fetchImpl })
+    const callsAfterFirst = fetchImpl.mock.calls.length
+    await getSpotifyData({ fetchImpl })
+    expect(fetchImpl).toHaveBeenCalledTimes(callsAfterFirst)
+  })
+})

--- a/tests/unit/services/data_sources/twitterDataSource.test.js
+++ b/tests/unit/services/data_sources/twitterDataSource.test.js
@@ -1,288 +1,80 @@
-/**
- * twitterDataSource.test.js
- * Unit tests for Twitter data source with manual input support
- */
+// tests/unit/services/data_sources/twitterDataSource.test.js
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-
-// Mock the config module with inline object to avoid hoisting issues
 vi.mock('../../../../src/config/config.js', () => ({
   config: {
-    twitter: {
-      enabled_api_fetch: false
-    },
-    profile: {
-      TWITTER_USERNAME: 'testuser'
-    },
-    cache: {
-      TWITTER_CACHE_TTL_MS: 3600000
-    },
-    apiDefaults: {
-      TWITTER_FOLLOWERS: '100'
-    }
-  }
-}));
+    twitter: { enabled_api_fetch: true },
+    profile: { TWITTER_USERNAME: 'u' },
+    cache: { TWITTER_CACHE_TTL_MS: 3600000 },
+    apiDefaults: { TWITTER_FOLLOWERS: '100' },
+  },
+}))
 
-describe('twitterDataSource', () => {
-  let mockFetch;
-  let originalEnv;
-  let consoleSpy;
-  let mockConfig;
-  let getTwitterData;
+let getTwitterData
+let config
+const originalEnv = process.env
+const noSleep = () => Promise.resolve()
+const okFetch = (body) =>
+  vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => body })
 
-  beforeEach(async () => {
-    // Clear module cache to ensure fresh imports
-    vi.resetModules();
-    
-    // Get the mocked config
-    const configModule = await import('../../../../src/config/config.js');
-    mockConfig = configModule.config;
-    
-    // Import the function fresh for each test
-    const twitterModule = await import('../../../../src/services/data_sources/twitterDataSource.js');
-    getTwitterData = twitterModule.getTwitterData;
-    
-    // Store original environment
-    originalEnv = process.env.TWITTER_BEARER_TOKEN;
-    
-    // Setup console spy
-    consoleSpy = {
-      info: vi.spyOn(console, 'info').mockImplementation(() => {}),
-      error: vi.spyOn(console, 'error').mockImplementation(() => {})
-    };
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.resetModules()
+  process.env = { ...originalEnv, TWITTER_BEARER_TOKEN: 'tok' }
+  config = (await import('../../../../src/config/config.js')).config
+  config.twitter.enabled_api_fetch = true // reset shared mock (mutated by disabled test)
+  ;({ getTwitterData } = await import('../../../../src/services/data_sources/twitterDataSource.js'))
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  process.env = originalEnv
+})
 
-    // Setup fetch mock
-    mockFetch = vi.fn();
-    global.fetch = mockFetch;
+describe('twitterDataSource — discriminated results', () => {
+  it('returns ok with the follower count when configured', async () => {
+    const fetchImpl = okFetch({ data: { public_metrics: { followers_count: 1234 } } })
+    const r = await getTwitterData({ fetchImpl, sleep: noSleep })
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({ twitterFollowers: '1234' })
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe('Bearer tok')
+  })
 
-    // Reset mock config to default state
-    mockConfig.twitter.enabled_api_fetch = false;
-    mockConfig.profile.TWITTER_USERNAME = 'testuser';
-  });
+  it('returns ok({}) (skip) when no bearer token is present (manual count used)', async () => {
+    delete process.env.TWITTER_BEARER_TOKEN
+    const fetchImpl = vi.fn()
+    const r = await getTwitterData({ fetchImpl, sleep: noSleep })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({})
+  })
 
-  afterEach(() => {
-    // Restore environment
-    if (originalEnv !== undefined) {
-      process.env.TWITTER_BEARER_TOKEN = originalEnv;
-    } else {
-      delete process.env.TWITTER_BEARER_TOKEN;
-    }
-    
-    // Restore all mocks
-    vi.restoreAllMocks();
-  });
+  it('returns ok({}) (skip) when API fetch is disabled', async () => {
+    config.twitter.enabled_api_fetch = false
+    const fetchImpl = vi.fn()
+    const r = await getTwitterData({ fetchImpl })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({})
+  })
 
-  describe('when API fetch is disabled', () => {
-    beforeEach(() => {
-      // Set config to disabled state
-      mockConfig.twitter.enabled_api_fetch = false;
-    });
+  it('returns a FALLBACK on an API error (distinguishable, carries status)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({}),
+    })
+    const r = await getTwitterData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.status).toBe('fallback')
+    expect(r.error.status).toBe(401)
+    expect(r.value).toEqual({ twitterFollowers: '100' })
+  })
 
-    it('should return empty object and log info message', async () => {
-      const result = await getTwitterData();
-      
-      expect(result).toEqual({});
-      expect(consoleSpy.info).toHaveBeenCalledWith('Twitter API fetch is disabled. Manual follower count will be used.');
-      expect(mockFetch).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('when API fetch is enabled', () => {
-    beforeEach(() => {
-      // Set config to enabled state
-      mockConfig.twitter.enabled_api_fetch = true;
-      mockConfig.profile.TWITTER_USERNAME = 'testuser';
-    });
-
-    describe('but no username is configured', () => {
-      beforeEach(() => {
-        mockConfig.profile.TWITTER_USERNAME = '';
-      });
-
-      it('should return empty object and log info message', async () => {
-        const result = await getTwitterData();
-        
-        expect(result).toEqual({});
-        expect(consoleSpy.info).toHaveBeenCalledWith('Twitter username not configured – skipping Twitter call.');
-        expect(mockFetch).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('but no bearer token is provided', () => {
-      beforeEach(() => {
-        delete process.env.TWITTER_BEARER_TOKEN;
-      });
-
-      it('should return empty object and log info message', async () => {
-        const result = await getTwitterData();
-        
-        expect(result).toEqual({});
-        expect(consoleSpy.info).toHaveBeenCalledWith('Twitter API fetch enabled but TWITTER_BEARER_TOKEN is missing. Manual follower count will be used.');
-        expect(mockFetch).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('with valid configuration', () => {
-      beforeEach(() => {
-        process.env.TWITTER_BEARER_TOKEN = 'test_token';
-      });
-
-      it('should successfully fetch and return follower count', async () => {
-        const mockResponse = {
-          data: {
-            public_metrics: {
-              followers_count: 1250
-            }
-          }
-        };
-
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve(mockResponse)
-        });
-
-        const result = await getTwitterData();
-
-        expect(result).toEqual({ twitterFollowers: '1250' });
-        expect(mockFetch).toHaveBeenCalledWith(
-          'https://api.twitter.com/2/users/by/username/testuser?user.fields=public_metrics',
-          {
-            headers: { Authorization: 'Bearer test_token' }
-          }
-        );
-        expect(consoleSpy.info).toHaveBeenCalledWith('Twitter data fetched & cached.');
-      });
-
-      it('should handle 401 unauthorized error', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status: 401,
-          statusText: 'Unauthorized'
-        });
-
-        const result = await getTwitterData();
-
-        expect(result).toEqual({ twitterFollowers: '100' });
-        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Unauthorized – invalid bearer token.');
-        expect(consoleSpy.info).toHaveBeenCalledWith('Using default follower count.');
-      });
-
-      it('should handle 403 forbidden error', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status: 403,
-          statusText: 'Forbidden'
-        });
-
-        const result = await getTwitterData();
-
-        expect(result).toEqual({ twitterFollowers: '100' });
-        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Forbidden – check app permissions.');
-      });
-
-      it('should handle 404 user not found error', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status: 404,
-          statusText: 'Not Found'
-        });
-
-        const result = await getTwitterData();
-
-        expect(result).toEqual({ twitterFollowers: '100' });
-        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'User "testuser" not found.');
-      });
-
-      it('should handle 429 rate limit error', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status: 429,
-          statusText: 'Too Many Requests'
-        });
-
-        const result = await getTwitterData();
-
-        expect(result).toEqual({ twitterFollowers: '100' });
-        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Rate‑limit exceeded.');
-      });
-
-      it('should handle other HTTP errors', async () => {
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status: 500,
-          statusText: 'Internal Server Error'
-        });
-
-        const result = await getTwitterData();
-
-        expect(result).toEqual({ twitterFollowers: '100' });
-        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Twitter API 500: Internal Server Error');
-      });
-
-      it('should handle invalid response data', async () => {
-        const mockResponse = {
-          data: {
-            public_metrics: {
-              followers_count: 'invalid'
-            }
-          }
-        };
-
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve(mockResponse)
-        });
-
-        const result = await getTwitterData();
-
-        expect(result).toEqual({ twitterFollowers: '100' });
-        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Twitter API returned invalid follower count.');
-      });
-
-      it('should handle network errors', async () => {
-        mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-        const result = await getTwitterData();
-
-        expect(result).toEqual({ twitterFollowers: '100' });
-        expect(consoleSpy.error).toHaveBeenCalledWith('Error fetching Twitter data:', 'Network error');
-      });
-
-      it('should return cached data when cache is fresh', async () => {
-        const mockResponse = {
-          data: {
-            public_metrics: {
-              followers_count: 1250
-            }
-          }
-        };
-
-        // Mock Date.now for consistent caching behavior
-        const mockDate = vi.spyOn(Date, 'now');
-        const baseTime = 1000000;
-        mockDate.mockReturnValue(baseTime);
-
-        // First call - should fetch from API
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve(mockResponse)
-        });
-
-        const firstResult = await getTwitterData();
-        expect(firstResult).toEqual({ twitterFollowers: '1250' });
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-
-        // Second call - should use cache (advance time but stay within cache TTL)
-        const cacheTime = baseTime + 1800000; // 30 minutes later (within 1 hour TTL)
-        mockDate.mockReturnValue(cacheTime);
-
-        const secondResult = await getTwitterData();
-        expect(secondResult).toEqual({ twitterFollowers: '1250' });
-        expect(mockFetch).toHaveBeenCalledTimes(1); // Still only 1 call - used cache
-        expect(consoleSpy.info).toHaveBeenCalledWith('Using cached Twitter data.');
-
-        mockDate.mockRestore();
-      });
-    });
-  });
-});
+  it('caches an ok result', async () => {
+    const fetchImpl = okFetch({ data: { public_metrics: { followers_count: 5 } } })
+    await getTwitterData({ fetchImpl, sleep: noSleep })
+    await getTwitterData({ fetchImpl, sleep: noSleep })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/services/data_sources/wakatimeDataSource.test.js
+++ b/tests/unit/services/data_sources/wakatimeDataSource.test.js
@@ -1,342 +1,100 @@
-// tests/unit/services/data_sources/wakatimeDataSource.test.js - COMPLETELY FIXED
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// tests/unit/services/data_sources/wakatimeDataSource.test.js
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-vi.mock('node-fetch', () => ({
-  default: vi.fn()
-}));
-
-vi.mock('../../../../src/services/utils/languageColors.js', () => ({
-  getLanguageColor: vi.fn(lang => `#${lang.toLowerCase()}`)
-}));
-
-// Mock the config module
 vi.mock('../../../../src/config/config.js', () => ({
   config: {
     wakatime: {
       enabled: true,
+      cacheTtlMs: 1800000,
       defaults: {
-        wakatime_summary: "No coding activity data available",
-        wakatime_top_language: "N/A",
-        wakatime_top_language_percent: "0",
-        wakatime_chart_data: []
-      },
-      cacheTtlMs: 7200000
-    },
-    profile: {
-      WAKATIME_USERNAME: 'testuser' // Default test value
-    }
-  }
-}));
-
-describe('wakatimeDataSource', () => {
-  let mockFetch;
-  let getWakaTimeData;
-  let config;
-  const originalEnv = process.env;
-
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.useFakeTimers();
-    
-    // Reset module
-    vi.resetModules();
-    
-    process.env = { ...originalEnv };
-    process.env.WAKATIME_API_KEY = 'test-api-key';
-    
-    // Import fresh modules
-    const configModule = await import('../../../../src/config/config.js');
-    config = configModule.config;
-    
-    // Set default test values
-    config.wakatime.enabled = true;
-    config.profile.WAKATIME_USERNAME = 'testuser';
-    
-    const module = await import('../../../../src/services/data_sources/wakatimeDataSource.js');
-    getWakaTimeData = module.getWakaTimeData;
-    
-    mockFetch = vi.fn();
-    if (typeof fetch === 'undefined') {
-      global.fetch = undefined;
-    }
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    process.env = originalEnv;
-    if (global.fetch === undefined) {
-      delete global.fetch;
-    }
-  });
-
-  describe('Configuration Checks', () => {
-    it('should skip when WakaTime is disabled', async () => {
-      config.wakatime.enabled = false;
-      global.fetch = mockFetch;
-
-      const result = await getWakaTimeData();
-
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({});
-    });
-
-    it('should handle missing API key', async () => {
-      delete process.env.WAKATIME_API_KEY;
-      global.fetch = mockFetch;
-
-      const result = await getWakaTimeData();
-
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual(config.wakatime.defaults);
-    });
-
-    it('should handle missing username', async () => {
-      config.profile.WAKATIME_USERNAME = '';
-      global.fetch = mockFetch;
-
-      const result = await getWakaTimeData();
-
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual(config.wakatime.defaults);
-    });
-  });
-
-  describe('Successful API Fetch & Caching', () => {
-    it('should fetch WakaTime data successfully in browser', async () => {
-      global.fetch = mockFetch;
-      global.btoa = vi.fn(str => Buffer.from(str).toString('base64'));
-      
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: {
-            human_readable_total_including_other_language: '25 hrs 30 mins',
-            languages: [
-              { name: 'JavaScript', percent: 65.5 },
-              { name: 'Python', percent: 20.3 },
-              { name: 'HTML', percent: 14.2 }
-            ]
-          }
-        })
-      });
-
-      const result = await getWakaTimeData();
-
-      expect(global.btoa).toHaveBeenCalledWith('test-api-key');
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://wakatime.com/api/v1/users/testuser/stats/last_7_days',
-        {
-          headers: {
-            'Authorization': 'Basic dGVzdC1hcGkta2V5',
-            'Accept': 'application/json'
-          }
-        }
-      );
-      expect(result).toEqual({
-        wakatime_summary: 'Coded for 25 hrs 30 mins in the last week',
-        wakatime_top_language: 'JavaScript',
-        wakatime_top_language_percent: '66',
-        wakatime_chart_data: [
-          { label: 'JavaScript', value: 66, color: '#javascript' },
-          { label: 'Python', value: 20, color: '#python' },
-          { label: 'HTML', value: 14, color: '#html' }
-        ]
-      });
-    });
-
-    it('should handle empty languages array', async () => {
-      global.fetch = mockFetch;
-      global.btoa = vi.fn(str => Buffer.from(str).toString('base64'));
-      
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: {
-            human_readable_total_including_other_language: '0 hrs',
-            languages: []
-          }
-        })
-      });
-
-      const result = await getWakaTimeData();
-
-      expect(result).toEqual({
-        wakatime_summary: 'Coded for 0 hrs in the last week',
+        wakatime_summary: 'No data',
         wakatime_top_language: 'None',
         wakatime_top_language_percent: '0',
-        wakatime_chart_data: []
-      });
-    });
+      },
+    },
+    profile: { WAKATIME_USERNAME: 'u' },
+  },
+}))
 
-    it('should limit chart data to top 5 languages', async () => {
-      global.fetch = mockFetch;
-      global.btoa = vi.fn(str => Buffer.from(str).toString('base64'));
-      
-      const languages = Array(10).fill(null).map((_, i) => ({
-        name: `Lang${i}`,
-        percent: 10 - i
-      }));
+let getWakaTimeData
+let config
+const originalEnv = process.env
+const noSleep = () => Promise.resolve()
+const okFetch = (body) =>
+  vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => body })
 
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: {
-            human_readable_total_including_other_language: '40 hrs',
-            languages
-          }
-        })
-      });
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.resetModules()
+  process.env = { ...originalEnv, WAKATIME_API_KEY: 'key' }
+  config = (await import('../../../../src/config/config.js')).config
+  config.wakatime.enabled = true // reset shared mock (mutated by disabled test)
+  ;({ getWakaTimeData } = await import(
+    '../../../../src/services/data_sources/wakatimeDataSource.js'
+  ))
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  process.env = originalEnv
+})
 
-      const result = await getWakaTimeData();
+describe('wakatimeDataSource — discriminated results', () => {
+  it('returns ok with summary, top language and chart data', async () => {
+    const fetchImpl = okFetch({
+      data: {
+        human_readable_total_including_other_language: '8 hrs',
+        languages: [
+          { name: 'JavaScript', percent: 65.4 },
+          { name: 'Python', percent: 20 },
+        ],
+      },
+    })
+    const r = await getWakaTimeData({ fetchImpl, sleep: noSleep })
+    expect(r.status).toBe('ok')
+    expect(r.value.wakatime_summary).toBe('Coded for 8 hrs in the last week')
+    expect(r.value.wakatime_top_language).toBe('JavaScript')
+    expect(r.value.wakatime_top_language_percent).toBe('65')
+    expect(r.value.wakatime_chart_data).toHaveLength(2)
+    expect(r.value.wakatime_chart_data[0]).toMatchObject({ label: 'JavaScript', value: 65 })
+  })
 
-      expect(result.wakatime_chart_data).toHaveLength(5);
-      expect(result.wakatime_chart_data[0].label).toBe('Lang0');
-      expect(result.wakatime_chart_data[4].label).toBe('Lang4');
-    });
+  it('returns ok({}) (skip) when disabled', async () => {
+    config.wakatime.enabled = false
+    const fetchImpl = vi.fn()
+    const r = await getWakaTimeData({ fetchImpl })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({})
+  })
 
-    it('should use cached data', async () => {
-      global.fetch = mockFetch;
-      global.btoa = vi.fn(str => Buffer.from(str).toString('base64'));
-      
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: {
-            human_readable_total_including_other_language: '10 hrs',
-            languages: [{ name: 'Go', percent: 100 }]
-          }
-        })
-      });
+  it('returns a FALLBACK when enabled but the API key is missing (misconfigured)', async () => {
+    delete process.env.WAKATIME_API_KEY
+    const fetchImpl = vi.fn()
+    const r = await getWakaTimeData({ fetchImpl, sleep: noSleep })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(r.status).toBe('fallback')
+    expect(r.value.wakatime_summary).toBe('No data')
+  })
 
-      await getWakaTimeData();
-      const result = await getWakaTimeData();
+  it('returns a FALLBACK on an API error (distinguishable, carries status)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({}),
+    })
+    const r = await getWakaTimeData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.status).toBe('fallback')
+    expect(r.error.status).toBe(401)
+  })
 
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(result.wakatime_top_language).toBe('Go');
-    });
-
-    it('should refresh after cache expires', async () => {
-      global.fetch = mockFetch;
-      global.btoa = vi.fn(str => Buffer.from(str).toString('base64'));
-      
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            data: {
-              human_readable_total_including_other_language: '5 hrs',
-              languages: [{ name: 'Rust', percent: 100 }]
-            }
-          })
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            data: {
-              human_readable_total_including_other_language: '10 hrs',
-              languages: [{ name: 'Go', percent: 100 }]
-            }
-          })
-        });
-
-      await getWakaTimeData();
-      vi.advanceTimersByTime(config.wakatime.cacheTtlMs + 1000);
-      const result = await getWakaTimeData();
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(result.wakatime_top_language).toBe('Go');
-    });
-  });
-
-  describe('API Error Handling', () => {
-    const errorTests = [
-      { status: 401, description: 'Unauthorized' },
-      { status: 403, description: 'Forbidden' },
-      { status: 404, description: 'User not found' },
-      { status: 429, description: 'Rate limit' },
-      { status: 500, description: 'Server error' }
-    ];
-
-    errorTests.forEach(({ status, description }) => {
-      it(`should handle ${status} ${description}`, async () => {
-        global.fetch = mockFetch;
-        global.btoa = vi.fn(str => Buffer.from(str).toString('base64'));
-        
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status,
-          statusText: description
-        });
-
-        const result = await getWakaTimeData();
-
-        expect(result).toEqual(config.wakatime.defaults);
-      });
-    });
-
-    it('should handle invalid response data', async () => {
-      global.fetch = mockFetch;
-      global.btoa = vi.fn(str => Buffer.from(str).toString('base64'));
-      
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({})
-      });
-
-      const result = await getWakaTimeData();
-
-      expect(result).toEqual(config.wakatime.defaults);
-    });
-
-    it('should handle network errors', async () => {
-      global.fetch = mockFetch;
-      global.btoa = vi.fn(str => Buffer.from(str).toString('base64'));
-      
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-      const result = await getWakaTimeData();
-
-      expect(result).toEqual(config.wakatime.defaults);
-    });
-  });
-
-  describe('Node Environment', () => {
-    it('should use Buffer for auth in Node', async () => {
-      delete global.fetch;
-      const nodeFetch = (await import('node-fetch')).default;
-      
-      nodeFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          data: {
-            human_readable_total_including_other_language: '15 hrs',
-            languages: [{ name: 'TypeScript', percent: 100 }]
-          }
-        })
-      });
-
-      const result = await getWakaTimeData();
-
-      expect(nodeFetch).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            'Authorization': expect.stringContaining('Basic ')
-          })
-        })
-      );
-      expect(result.wakatime_top_language).toBe('TypeScript');
-    });
-
-    it('should handle Node environment errors', async () => {
-      delete global.fetch;
-      const nodeFetch = (await import('node-fetch')).default;
-      nodeFetch.mockRejectedValueOnce(new Error('Node error'));
-
-      const result = await getWakaTimeData();
-
-      expect(result).toEqual(config.wakatime.defaults);
-    });
-  });
-});
+  it('caches an ok result', async () => {
+    const fetchImpl = okFetch({
+      data: { human_readable_total_including_other_language: '1 hr', languages: [] },
+    })
+    await getWakaTimeData({ fetchImpl, sleep: noSleep })
+    await getWakaTimeData({ fetchImpl, sleep: noSleep })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/services/data_sources/weatherDataSource.test.js
+++ b/tests/unit/services/data_sources/weatherDataSource.test.js
@@ -1,316 +1,127 @@
 // tests/unit/services/data_sources/weatherDataSource.test.js
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-vi.mock('node-fetch', () => ({
-  default: vi.fn()
-}));
-
-// Mock the config module 
 vi.mock('../../../../src/config/config.js', () => ({
   config: {
-    weather: {
-      enabled: true 
-    },
-    cache: {
-      WEATHER_CACHE_TTL_MS: 1800000
-    },
+    weather: { enabled: true },
+    cache: { WEATHER_CACHE_TTL_MS: 1800000 },
     apiDefaults: {
-      TEMPERATURE: "72°F (22°C)",
-      WEATHER_DESCRIPTION: "partly cloudy",
-      WEATHER_EMOJI: "⛅"
-    }
-  }
-}));
+      TEMPERATURE: '72°F (22°C)',
+      WEATHER_DESCRIPTION: 'partly cloudy',
+      WEATHER_EMOJI: '⛅',
+    },
+  },
+}))
 
-describe('weatherDataSource', () => {
-  let mockFetch;
-  let getWeatherData;
-  let config;
-  const originalEnv = process.env;
+let getWeatherData
+let config
+const originalEnv = process.env
+const noSleep = () => Promise.resolve()
+const okFetch = (body) =>
+  vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => body })
 
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    vi.useFakeTimers();
-    
-    // Reset environment
-    process.env = { ...originalEnv };
-    process.env.WEATHER_API_KEY = 'test-api-key';
-    process.env.LOCATION_KEY = 'test-location-key';
-    
-    // Clear the module cache and re-import to reset module-level cache
-    vi.resetModules();
-    
-    // Import fresh modules
-    const configModule = await import('../../../../src/config/config.js');
-    config = configModule.config;
-    
-    const module = await import('../../../../src/services/data_sources/weatherDataSource.js');
-    getWeatherData = module.getWeatherData;
-    
-    // Setup fetch mock
-    mockFetch = vi.fn();
-    if (typeof fetch === 'undefined') {
-      global.fetch = undefined;
-    }
-  });
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.resetModules()
+  process.env = { ...originalEnv, WEATHER_API_KEY: 'k', LOCATION_KEY: 'loc' }
+  config = (await import('../../../../src/config/config.js')).config
+  ;({ getWeatherData } = await import('../../../../src/services/data_sources/weatherDataSource.js'))
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  process.env = originalEnv
+})
 
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    process.env = originalEnv;
-    if (global.fetch === undefined) {
-      delete global.fetch;
-    }
-  });
+describe('weatherDataSource — discriminated results', () => {
+  it('returns ok with formatted temperature, description and emoji', async () => {
+    const fetchImpl = okFetch([{ Temperature: { Imperial: { Value: 75 } }, WeatherText: 'Sunny' }])
+    const r = await getWeatherData({ fetchImpl, sleep: noSleep })
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({
+      temperature: '75°F (24°C)',
+      weatherDescription: 'sunny',
+      emoji: '☀️',
+    })
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      'https://dataservice.accuweather.com/currentconditions/v1/loc?apikey=k'
+    )
+  })
 
-  describe('Successful API Fetch & Caching', () => {
-    it('should fetch weather data successfully in browser environment', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{
-          Temperature: {
-            Imperial: { Value: 75 }
-          },
-          WeatherText: 'Sunny'
-        }]
-      });
+  it.each([
+    ['Sunny', '☀️'],
+    ['Mostly Sunny', '🌤️'],
+    ['Partly Cloudy', '⛅'],
+    ['Cloudy', '☁️'],
+    ['Rain', '🌧️'],
+    ['Thunderstorm', '⛈️'],
+    ['Snow', '❄️'],
+    ['Fog', '🌫️'],
+    ['Unknown Weather', '⛅'],
+  ])('maps "%s" to %s', async (text, emoji) => {
+    const fetchImpl = okFetch([{ Temperature: { Imperial: { Value: 70 } }, WeatherText: text }])
+    const r = await getWeatherData({ fetchImpl, sleep: noSleep })
+    expect(r.value.emoji).toBe(emoji)
+  })
 
-      const result = await getWeatherData();
+  it('caches an ok result', async () => {
+    const fetchImpl = okFetch([{ Temperature: { Imperial: { Value: 70 } }, WeatherText: 'Clear' }])
+    await getWeatherData({ fetchImpl, sleep: noSleep })
+    await getWeatherData({ fetchImpl, sleep: noSleep })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        `https://dataservice.accuweather.com/currentconditions/v1/test-location-key?apikey=test-api-key`
-      );
-      expect(result).toEqual({
-        temperature: '75°F (24°C)',
-        weatherDescription: 'sunny',
-        emoji: '☀️'
-      });
-    });
-
-    it('should fetch weather data successfully in Node environment', async () => {
-      delete global.fetch;
-      const nodeFetch = (await import('node-fetch')).default;
-      nodeFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{
-          Temperature: {
-            Imperial: { Value: 32 }
-          },
-          WeatherText: 'Snow'
-        }]
-      });
-
-      const result = await getWeatherData();
-
-      expect(nodeFetch).toHaveBeenCalled();
-      expect(result).toEqual({
-        temperature: '32°F (0°C)',
-        weatherDescription: 'snow',
-        emoji: '❄️'
-      });
-    });
-
-    it('should return cached data on second call', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{
-          Temperature: { Imperial: { Value: 70 } },
-          WeatherText: 'Partly Cloudy'
-        }]
-      });
-
-      // First call
-      const result1 = await getWeatherData();
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-
-      // Second call immediately
-      const result2 = await getWeatherData();
-      expect(mockFetch).toHaveBeenCalledTimes(1); // Still 1
-      expect(result2).toEqual(result1);
-    });
-
-    it('should fetch new data after cache expires', async () => {
-      global.fetch = mockFetch;
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{
-            Temperature: { Imperial: { Value: 65 } },
-            WeatherText: 'Clear'
-          }]
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{
-            Temperature: { Imperial: { Value: 80 } },
-            WeatherText: 'Hot'
-          }]
-        });
-
-      // First call
-      await getWeatherData();
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-
-      // Advance time past cache TTL
-      vi.advanceTimersByTime(config.cache.WEATHER_CACHE_TTL_MS + 1000);
-
-      // Second call after cache expiry
-      const result = await getWeatherData();
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(result.temperature).toBe('80°F (27°C)');
-    });
-  });
-
-  describe('API Error Handling', () => {
-    it('should handle 401 Unauthorized error', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
+  it('returns a FALLBACK (defaults + error) on an API error — distinguishable', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue({
         ok: false,
         status: 401,
-        statusText: 'Unauthorized'
-      });
+        statusText: 'Unauthorized',
+        json: async () => ({}),
+      })
+    const r = await getWeatherData({ fetchImpl, sleep: noSleep, retries: 0 })
+    expect(r.status).toBe('fallback')
+    expect(r.error.status).toBe(401)
+    expect(r.value).toEqual({
+      temperature: config.apiDefaults.TEMPERATURE,
+      weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
+      emoji: config.apiDefaults.WEATHER_EMOJI,
+    })
+  })
 
-      const result = await getWeatherData();
+  it('returns a FALLBACK on empty data', async () => {
+    const r = await getWeatherData({ fetchImpl: okFetch([]), sleep: noSleep })
+    expect(r.status).toBe('fallback')
+  })
 
-      expect(result).toEqual({
-        temperature: config.apiDefaults.TEMPERATURE,
-        weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
-        emoji: config.apiDefaults.WEATHER_EMOJI
-      });
-    });
+  it('returns ok({}) (skip) when API/location keys are missing', async () => {
+    delete process.env.WEATHER_API_KEY
+    const fetchImpl = vi.fn()
+    const r = await getWeatherData({ fetchImpl, sleep: noSleep })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({})
+  })
+})
 
-    it('should handle 429 Rate Limit error', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 429,
-        statusText: 'Too Many Requests'
-      });
-
-      const result = await getWeatherData();
-
-      expect(result).toEqual({
-        temperature: config.apiDefaults.TEMPERATURE,
-        weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
-        emoji: config.apiDefaults.WEATHER_EMOJI
-      });
-    });
-
-    it('should handle network errors', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockRejectedValueOnce(new Error('Network error'));
-
-      const result = await getWeatherData();
-
-      expect(result).toEqual({
-        temperature: config.apiDefaults.TEMPERATURE,
-        weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
-        emoji: config.apiDefaults.WEATHER_EMOJI
-      });
-    });
-
-    it('should handle empty API response', async () => {
-      global.fetch = mockFetch;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => []
-      });
-
-      const result = await getWeatherData();
-
-      expect(result).toEqual({
-        temperature: config.apiDefaults.TEMPERATURE,
-        weatherDescription: config.apiDefaults.WEATHER_DESCRIPTION,
-        emoji: config.apiDefaults.WEATHER_EMOJI
-      });
-    });
-  });
-
-  describe('Missing Environment Variables', () => {
-    it('should handle missing API key', async () => {
-      delete process.env.WEATHER_API_KEY;
-      global.fetch = mockFetch;
-
-      const result = await getWeatherData();
-
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({});
-    });
-
-    it('should handle missing location key', async () => {
-      delete process.env.LOCATION_KEY;
-      global.fetch = mockFetch;
-
-      const result = await getWeatherData();
-
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({});
-    });
-  });
-
-  describe('Weather Emoji Processing', () => {
-    const weatherEmojiTests = [
-      { text: 'Sunny', emoji: '☀️' },
-      { text: 'Clear skies', emoji: '☀️' },
-      { text: 'Mostly Sunny', emoji: '🌤️' },
-      { text: 'Partly Cloudy', emoji: '⛅' },
-      { text: 'Cloudy', emoji: '☁️' },
-      { text: 'Rain', emoji: '🌧️' },
-      { text: 'Thunderstorm', emoji: '⛈️' },
-      { text: 'Snow', emoji: '❄️' },
-      { text: 'Fog', emoji: '🌫️' },
-      { text: 'Unknown Weather', emoji: '⛅' } // Default
-    ];
-
-    weatherEmojiTests.forEach(({ text, emoji }) => {
-      it(`should return ${emoji} for "${text}"`, async () => {
-        global.fetch = mockFetch;
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{
-            Temperature: { Imperial: { Value: 70 } },
-            WeatherText: text
-          }]
-        });
-
-        const result = await getWeatherData();
-        expect(result.emoji).toBe(emoji);
-      });
-    });
-  });
-
-  describe('Weather Configuration', () => {
-    it('should skip weather fetch when config.weather.enabled is false', async () => {
-      // Mock config with weather disabled
-      vi.doMock('../../../../src/config/config.js', () => ({
-        config: {
-          weather: {
-            enabled: false
-          },
-          cache: {
-            WEATHER_CACHE_TTL_MS: 1800000
-          },
-          apiDefaults: {
-            TEMPERATURE: "72°F (22°C)",
-            WEATHER_DESCRIPTION: "partly cloudy",
-            WEATHER_EMOJI: "⛅"
-          }
-        }
-      }));
-
-      // Re-import to get updated config
-      vi.resetModules();
-      const module = await import('../../../../src/services/data_sources/weatherDataSource.js');
-      const getWeatherDataDisabled = module.getWeatherData;
-      
-      global.fetch = mockFetch;
-
-      const result = await getWeatherDataDisabled();
-
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(result).toEqual({});
-    });
-  });
-});
+describe('weatherDataSource — disabled', () => {
+  it('returns ok({}) (skip) when weather is disabled', async () => {
+    vi.resetModules()
+    vi.doMock('../../../../src/config/config.js', () => ({
+      config: {
+        weather: { enabled: false },
+        cache: { WEATHER_CACHE_TTL_MS: 1 },
+        apiDefaults: { TEMPERATURE: 'x', WEATHER_DESCRIPTION: 'y', WEATHER_EMOJI: 'z' },
+      },
+    }))
+    const { getWeatherData: disabled } = await import(
+      '../../../../src/services/data_sources/weatherDataSource.js'
+    )
+    const fetchImpl = vi.fn()
+    const r = await disabled({ fetchImpl })
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(r.status).toBe('ok')
+    expect(r.value).toEqual({})
+  })
+})


### PR DESCRIPTION
## feat(reliability): convert remaining data sources to discriminated results (PR-5a.2)

Completes the data-source contract started in PR-5a so **PR-5b's status manifest can cover every source**. `weather`, `wakatime`, `codestats`, `twitter`, and `spotify` now return `{ status, value, error, fetchedAt }` instead of returning defaults indistinguishably from live data.

### Changes
- **weather / wakatime / codestats / twitter** — use the shared `httpClient` (timeout + retry/backoff + fail-fast on auth/config 4xx). Dead `node-fetch` branches removed.
- **spotify** — keeps a bespoke fetch because **204 "nothing playing" is a SUCCESS**, not an error; it now classifies auth/rate-limit/server failures as `fallback` carrying `.status`, while "not listening" is `ok` with the default string.
- **Intentional skips** (disabled integration, missing username/token) return `ok({})` — no failure to flag — **distinct** from configured-but-failed (`fallback`).
- **DataService** unwraps `.value` for all six rendered sources and records per-source status for **all seven** on `lastSourceStatuses` (reset each run, per the PR-5a follow-up); the Twitter manual-input priority now reads `twitter.value`.

### Scope (as approved)
Data-source contract + DataService capture only. **No** manifest/Actions/alerting (PR-5b), **no** GraphQL commits (PR-5c), **no** visual change.

### Acceptance
- [x] Each converted source has tests proving `ok` and `fallback` are distinguishable.
- [x] Auth/config failures classified (carry `.status`: 401/403/404/429).
- [x] Retryable network/server failures use the shared HTTP helper (where applicable; Spotify documented exception).
- [x] Existing renderer/build behavior compatible (integration SVG flow green; CI `build` renders).
- [x] `npm run verify` passes.
- [x] Generated SVG output materially unchanged.

### Verify
`npm run verify` → **446 tests pass**, coverage **93.78% stmts** (up from 90.7), configurator build green, eslint clean. **Net −1,347 lines** (dead `node-fetch` branches + duplication removed).

This is the final data-source conversion layer needed before **PR-5b** (status manifest + staleness guard + Actions summary + auto-issue, flagging 401/403/429 as high-signal auth/rate-limit).
