### PR TITLE
ci: bump actions to Node-24 majors; CI Node 20 -> 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ permissions:
   contents: write
 
 env:
-  NODE_VERSION: '20.x'
+  NODE_VERSION: '24'
 
 jobs:
   build:
@@ -36,12 +36,12 @@ jobs:
       timestamp: ${{ steps.ts.outputs.ts }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload artifacts
         if: steps.diff.outputs.changed == 'true' && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: updated-files
           path: |
@@ -118,13 +118,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.PROFILECHATTER_ACTION_COMMIT_TOKEN }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: updated-files
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -46,6 +46,6 @@ jobs:
         run: npm run config:build
 
       - name: Secret scan (gitleaks)
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Clears the Node-20 actions deprecation warning.

- checkout v4->v6, setup-node v4->v6, upload-artifact v4->v7, download-artifact v4->v8, gitleaks v2->v3
- CI Node 20 -> 24 (matches local dev + current LTS; engines >=20 still satisfied)

The PR's `verify` run exercises Node 24 + the new action majors. Does **not** fix the `commit` job auth failure — that is an **expired `PROFILECHATTER_ACTION_COMMIT_TOKEN`** (rotate the secret), separate from this workflow change.