### PR TITLE
feat(reliability): source status manifest — observability (PR-5b-i)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,7 @@ jobs:
           path: |
             dist/profile-chat.svg
             README.md
+            dist/status-manifest.json
 
       - name: Summary
         run: |

--- a/src/build-profile.js
+++ b/src/build-profile.js
@@ -9,9 +9,11 @@
  * External HTTP/HTTPS URLs will NOT display in GitHub READMEs due to CSP restrictions.
  */
 import { generateChatSVG } from './ProfileChatter.js'
-import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs'
+import { writeFileSync, appendFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs'
 import path from 'node:path'
 import { config } from './config/config.js'
+import DataService from './services/DataService.js'
+import { emitStatusManifest } from './services/utils/statusManifest.js'
 
 /**
  * Embed local avatar image as a base64 data URI
@@ -210,6 +212,23 @@ generateChatSVG(customContext)
     // Write SVG to file
     writeFileSync('dist/profile-chat.svg', svg)
     console.log('✅ SVG written to dist/profile-chat.svg')
+
+    // Emit the per-source status manifest (PR-5b-i observability): machine-readable
+    // JSON + a GitHub Actions step summary, so a green build can no longer hide a
+    // configured source that quietly fell back. Intentional skips do not alarm.
+    const manifest = emitStatusManifest(DataService.lastSourceStatuses, {
+      manifestPath: 'dist/status-manifest.json',
+      stepSummaryPath: process.env.GITHUB_STEP_SUMMARY,
+      writeFile: writeFileSync,
+      appendFile: appendFileSync,
+    })
+    console.log(
+      `📊 Status manifest: ${manifest.summary.live} live, ${manifest.summary.skip} skip, ` +
+        `${manifest.summary.fallback} fallback, ${manifest.summary.error} error` +
+        (manifest.summary.alerting
+          ? ` (alerting — ${manifest.summary.highSignal} high-signal)`
+          : '')
+    )
   })
   .catch((error) => {
     console.error('Error generating SVG:', error)

--- a/src/build-profile.js
+++ b/src/build-profile.js
@@ -2,16 +2,16 @@
  * build-profile.js
  * Build script for generating the profile SVG
  * Single Responsibility: Build automation
- * 
+ *
  * IMPORTANT: For GitHub README compatibility, avatar images should be:
  * 1. Base64 data URIs (preferred, works everywhere)
  * 2. Local assets (fallback, automatically embedded as Base64)
  * External HTTP/HTTPS URLs will NOT display in GitHub READMEs due to CSP restrictions.
  */
-import { generateChatSVG } from './ProfileChatter.js';
-import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
-import path from 'node:path';
-import { config } from './config/config.js';
+import { generateChatSVG } from './ProfileChatter.js'
+import { writeFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import { config } from './config/config.js'
 
 /**
  * Embed local avatar image as a base64 data URI
@@ -23,22 +23,23 @@ import { config } from './config/config.js';
 function embedAvatarLocal(sender, filePath, targetAvatarConfig) {
   try {
     if (!existsSync(filePath)) {
-      console.warn(`Local avatar asset not found: ${filePath}`);
-      return false;
+      console.warn(`Local avatar asset not found: ${filePath}`)
+      return false
     }
-    
-    const abs = path.resolve(filePath);
-    const mime = filePath.toLowerCase().endsWith('.jpg') || filePath.toLowerCase().endsWith('.jpeg') 
-      ? 'image/jpeg' 
-      : 'image/png';
-    const b64 = readFileSync(abs).toString('base64');
-    targetAvatarConfig[sender].imageUrl = `data:${mime};base64,${b64}`;
-    console.log(`✅ Embedded local ${sender} avatar from ${filePath}`);
-    return true;
+
+    const abs = path.resolve(filePath)
+    const mime =
+      filePath.toLowerCase().endsWith('.jpg') || filePath.toLowerCase().endsWith('.jpeg')
+        ? 'image/jpeg'
+        : 'image/png'
+    const b64 = readFileSync(abs).toString('base64')
+    targetAvatarConfig[sender].imageUrl = `data:${mime};base64,${b64}`
+    console.log(`✅ Embedded local ${sender} avatar from ${filePath}`)
+    return true
   } catch (error) {
-    console.warn(`Failed to embed local avatar for ${sender}: ${error.message}`);
-    targetAvatarConfig[sender].imageUrl = ''; // Ensure it's empty on error
-    return false;
+    console.warn(`Failed to embed local avatar for ${sender}: ${error.message}`)
+    targetAvatarConfig[sender].imageUrl = '' // Ensure it's empty on error
+    return false
   }
 }
 
@@ -48,7 +49,7 @@ function embedAvatarLocal(sender, filePath, targetAvatarConfig) {
  * @returns {boolean} - Whether the URL is external
  */
 function isExternalUrl(url) {
-  return typeof url === 'string' && (url.startsWith('http://') || url.startsWith('https://'));
+  return typeof url === 'string' && (url.startsWith('http://') || url.startsWith('https://'))
 }
 
 /**
@@ -57,142 +58,160 @@ function isExternalUrl(url) {
  * @returns {boolean} - Whether the URL is a valid data URI
  */
 function isDataUri(url) {
-  return typeof url === 'string' && url.startsWith('data:image/');
+  return typeof url === 'string' && url.startsWith('data:image/')
 }
 
 // Ensure dist directory exists
-mkdirSync('dist', { recursive: true });
+mkdirSync('dist', { recursive: true })
 
 // Attempt to load profileChatterConfig.json
-let loadedUiConfig = null;
-const configFilePath = './profileChatterConfig.json';
+let loadedUiConfig = null
+const configFilePath = './profileChatterConfig.json'
 if (existsSync(configFilePath)) {
   try {
-    const configFileContent = readFileSync(configFilePath, 'utf8');
-    loadedUiConfig = JSON.parse(configFileContent);
-    console.log('✅ Found profileChatterConfig.json. Applying custom UI configuration.');
+    const configFileContent = readFileSync(configFilePath, 'utf8')
+    loadedUiConfig = JSON.parse(configFileContent)
+    console.log('✅ Found profileChatterConfig.json. Applying custom UI configuration.')
   } catch (error) {
-    console.warn(`Failed to load custom configuration: ${error.message}. Proceeding with defaults and local asset fallbacks.`);
-    loadedUiConfig = null; // Ensure it's null on error
+    console.warn(
+      `Failed to load custom configuration: ${error.message}. Proceeding with defaults and local asset fallbacks.`
+    )
+    loadedUiConfig = null // Ensure it's null on error
   }
 }
 
 // Initialize effectiveAvatarConfig, prioritizing loadedUiConfig if available
-let effectiveAvatarConfig = { 
+let effectiveAvatarConfig = {
   enabled: loadedUiConfig?.avatars?.enabled ?? config.avatars.enabled,
-  me: { 
+  me: {
     imageUrl: '', // Start with empty and fill based on logic below
-    fallbackText: loadedUiConfig?.avatars?.me?.fallbackText ?? config.avatars.me.fallbackText
+    fallbackText: loadedUiConfig?.avatars?.me?.fallbackText ?? config.avatars.me.fallbackText,
   },
-  visitor: { 
+  visitor: {
     imageUrl: '', // Start with empty and fill based on logic below
-    fallbackText: loadedUiConfig?.avatars?.visitor?.fallbackText ?? config.avatars.visitor.fallbackText
+    fallbackText:
+      loadedUiConfig?.avatars?.visitor?.fallbackText ?? config.avatars.visitor.fallbackText,
   },
   sizePx: loadedUiConfig?.avatars?.sizePx ?? config.avatars.sizePx,
   shape: loadedUiConfig?.avatars?.shape ?? config.avatars.shape,
   xOffsetPx: loadedUiConfig?.avatars?.xOffsetPx ?? config.avatars.xOffsetPx,
-  yOffsetPx: loadedUiConfig?.avatars?.yOffsetPx ?? config.avatars.yOffsetPx
-};
+  yOffsetPx: loadedUiConfig?.avatars?.yOffsetPx ?? config.avatars.yOffsetPx,
+}
 
 // Process avatar URLs in order of preference: Data URI > Local Asset > External URL
 // The "me" avatar
 if (loadedUiConfig?.avatars?.me?.imageUrl) {
-  const meImageUrl = loadedUiConfig.avatars.me.imageUrl;
-  
+  const meImageUrl = loadedUiConfig.avatars.me.imageUrl
+
   if (isDataUri(meImageUrl)) {
     // If it's a data URI, use it directly (most preferred)
-    effectiveAvatarConfig.me.imageUrl = meImageUrl;
-    console.log('Using data URI for ME avatar from profileChatterConfig.json');
+    effectiveAvatarConfig.me.imageUrl = meImageUrl
+    console.log('Using data URI for ME avatar from profileChatterConfig.json')
   } else if (isExternalUrl(meImageUrl)) {
     // If it's an external URL, store it but attempt to use local asset first
-    console.log(`WARNING: External URL detected for ME avatar: "${meImageUrl}". This may not display in GitHub READMEs due to CSP restrictions.`);
-    effectiveAvatarConfig.me.externalUrl = meImageUrl;
+    console.log(
+      `WARNING: External URL detected for ME avatar: "${meImageUrl}". This may not display in GitHub READMEs due to CSP restrictions.`
+    )
+    effectiveAvatarConfig.me.externalUrl = meImageUrl
     // Will try local asset embedding below, then fall back to this external URL
   } else {
-    console.warn(`Invalid ME avatar URL format: "${meImageUrl}". Will try local asset fallback.`);
+    console.warn(`Invalid ME avatar URL format: "${meImageUrl}". Will try local asset fallback.`)
   }
 }
 
 // The "visitor" avatar
 if (loadedUiConfig?.avatars?.visitor?.imageUrl) {
-  const visitorImageUrl = loadedUiConfig.avatars.visitor.imageUrl;
-  
+  const visitorImageUrl = loadedUiConfig.avatars.visitor.imageUrl
+
   if (isDataUri(visitorImageUrl)) {
     // If it's a data URI, use it directly (most preferred)
-    effectiveAvatarConfig.visitor.imageUrl = visitorImageUrl;
-    console.log('Using data URI for VISITOR avatar from profileChatterConfig.json');
+    effectiveAvatarConfig.visitor.imageUrl = visitorImageUrl
+    console.log('Using data URI for VISITOR avatar from profileChatterConfig.json')
   } else if (isExternalUrl(visitorImageUrl)) {
     // If it's an external URL, store it but attempt to use local asset first
-    console.log(`WARNING: External URL detected for VISITOR avatar: "${visitorImageUrl}". This may not display in GitHub READMEs due to CSP restrictions.`);
-    effectiveAvatarConfig.visitor.externalUrl = visitorImageUrl;
+    console.log(
+      `WARNING: External URL detected for VISITOR avatar: "${visitorImageUrl}". This may not display in GitHub READMEs due to CSP restrictions.`
+    )
+    effectiveAvatarConfig.visitor.externalUrl = visitorImageUrl
     // Will try local asset embedding below, then fall back to this external URL
   } else {
-    console.warn(`Invalid VISITOR avatar URL format: "${visitorImageUrl}". Will try local asset fallback.`);
+    console.warn(
+      `Invalid VISITOR avatar URL format: "${visitorImageUrl}". Will try local asset fallback.`
+    )
   }
 }
 
 // Apply local asset embedding as a fallback if imageUrl is still empty
 if (effectiveAvatarConfig.enabled) {
-  const avatarDir = path.join(process.cwd(), 'assets');
+  const avatarDir = path.join(process.cwd(), 'assets')
   if (!existsSync(avatarDir)) {
-    mkdirSync(avatarDir, { recursive: true });
-    console.log('✅ Created assets directory for avatars');
+    mkdirSync(avatarDir, { recursive: true })
+    console.log('✅ Created assets directory for avatars')
   }
 
   // Try local asset for ME avatar if needed
   if (!effectiveAvatarConfig.me.imageUrl) {
-    const myAvatarPath = path.join(avatarDir, 'me-avatar.png');
+    const myAvatarPath = path.join(avatarDir, 'me-avatar.png')
     if (embedAvatarLocal('me', myAvatarPath, effectiveAvatarConfig)) {
-      console.log('✅ Applied local asset for ME avatar as fallback.');
+      console.log('✅ Applied local asset for ME avatar as fallback.')
     } else if (effectiveAvatarConfig.me.externalUrl) {
       // If local fallback fails, use the original external URL as last resort
-      console.log('⚠️ Local ME avatar not found. Using external URL as last resort (will not show on GitHub).');
-      effectiveAvatarConfig.me.imageUrl = effectiveAvatarConfig.me.externalUrl;
+      console.log(
+        '⚠️ Local ME avatar not found. Using external URL as last resort (will not show on GitHub).'
+      )
+      effectiveAvatarConfig.me.imageUrl = effectiveAvatarConfig.me.externalUrl
     }
   }
-  
+
   // Try local asset for VISITOR avatar if needed
   if (!effectiveAvatarConfig.visitor.imageUrl) {
-    const visitorAvatarPath = path.join(avatarDir, 'visitor-avatar.png');
+    const visitorAvatarPath = path.join(avatarDir, 'visitor-avatar.png')
     if (embedAvatarLocal('visitor', visitorAvatarPath, effectiveAvatarConfig)) {
-      console.log('✅ Applied local asset for VISITOR avatar as fallback.');
+      console.log('✅ Applied local asset for VISITOR avatar as fallback.')
     } else if (effectiveAvatarConfig.visitor.externalUrl) {
       // If local fallback fails, use the original external URL as last resort
-      console.log('⚠️ Local VISITOR avatar not found. Using external URL as last resort (will not show on GitHub).');
-      effectiveAvatarConfig.visitor.imageUrl = effectiveAvatarConfig.visitor.externalUrl;
+      console.log(
+        '⚠️ Local VISITOR avatar not found. Using external URL as last resort (will not show on GitHub).'
+      )
+      effectiveAvatarConfig.visitor.imageUrl = effectiveAvatarConfig.visitor.externalUrl
     }
   }
 }
 
 // Add a final warning if any external URLs are still being used
-if (isExternalUrl(effectiveAvatarConfig.me.imageUrl) || isExternalUrl(effectiveAvatarConfig.visitor.imageUrl)) {
-  console.log('\n⚠️ GITHUB COMPATIBILITY WARNING ⚠️');
-  console.log('External URLs are being used for avatars. These will NOT display in GitHub READMEs.');
-  console.log('For GitHub compatibility, use Base64 data URIs in the Configurator UI,');
-  console.log('or place PNG images in the assets/ directory named me-avatar.png and visitor-avatar.png.\n');
+if (
+  isExternalUrl(effectiveAvatarConfig.me.imageUrl) ||
+  isExternalUrl(effectiveAvatarConfig.visitor.imageUrl)
+) {
+  console.log('\n⚠️ GITHUB COMPATIBILITY WARNING ⚠️')
+  console.log('External URLs are being used for avatars. These will NOT display in GitHub READMEs.')
+  console.log('For GitHub compatibility, use Base64 data URIs in the Configurator UI,')
+  console.log(
+    'or place PNG images in the assets/ directory named me-avatar.png and visitor-avatar.png.\n'
+  )
 }
 
 // Prepare customContext for generateChatSVG
-let customContext = {};
+let customContext = {}
 if (loadedUiConfig) {
   customContext = {
     profile: loadedUiConfig.profile,
     activeTheme: loadedUiConfig.activeTheme,
     chatMessages: loadedUiConfig.chatMessages,
-    themeOverrides: loadedUiConfig.themeOverrides
-  };
+    themeOverrides: loadedUiConfig.themeOverrides,
+  }
 }
 // Pass the processed effectiveAvatarConfig to generateChatSVG
-customContext.avatars = effectiveAvatarConfig; 
+customContext.avatars = effectiveAvatarConfig
 
 // Generate SVG with configured data
 generateChatSVG(customContext)
-  .then(svg => {
+  .then((svg) => {
     // Write SVG to file
-    writeFileSync('dist/profile-chat.svg', svg);
-    console.log('✅ SVG written to dist/profile-chat.svg');
+    writeFileSync('dist/profile-chat.svg', svg)
+    console.log('✅ SVG written to dist/profile-chat.svg')
   })
-  .catch(error => {
-    console.error('Error generating SVG:', error);
-    process.exit(1);
-  });
+  .catch((error) => {
+    console.error('Error generating SVG:', error)
+    process.exit(1)
+  })

--- a/src/services/DataService.js
+++ b/src/services/DataService.js
@@ -12,6 +12,7 @@ import { getCodeStatsData } from './data_sources/codestatsDataSource.js'
 import { getSpotifyData } from './data_sources/spotifyDataSource.js'
 import { getGitHubOAuthData } from './data_sources/githubOAuthDataSource.js'
 import DateTimeFormatService from './DateTimeFormatService.js'
+import { classifySource } from './utils/statusManifest.js'
 
 /* ---------- service ------------------------------------------------------ */
 class DataService {
@@ -117,6 +118,7 @@ class DataService {
         this.lastSourceStatuses = Object.entries(sources).map(([source, r]) => ({
           source,
           status: r.status,
+          classification: classifySource(r),
           error: r.error,
           fetchedAt: r.fetchedAt,
         }))

--- a/src/services/utils/statusManifest.js
+++ b/src/services/utils/statusManifest.js
@@ -108,3 +108,20 @@ export function renderStepSummary(manifest) {
     '',
   ].join('\n')
 }
+
+/**
+ * Build the manifest, write it as machine-readable JSON, and (in CI) append the
+ * markdown step summary. fs writers are injected so build-profile.js stays thin
+ * glue and this is unit-testable without touching disk.
+ * @param {Array} statuses - DataService.lastSourceStatuses
+ * @param {{ generatedAt?: number, manifestPath: string, stepSummaryPath?: string,
+ *           writeFile: (p:string,c:string)=>void, appendFile: (p:string,c:string)=>void }} opts
+ * @returns {ReturnType<typeof buildStatusManifest>}
+ */
+export function emitStatusManifest(statuses, opts) {
+  const { generatedAt, manifestPath, stepSummaryPath, writeFile, appendFile } = opts
+  const manifest = buildStatusManifest(statuses, { generatedAt })
+  writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+  if (stepSummaryPath) appendFile(stepSummaryPath, `${renderStepSummary(manifest)}\n`)
+  return manifest
+}

--- a/src/services/utils/statusManifest.js
+++ b/src/services/utils/statusManifest.js
@@ -1,0 +1,110 @@
+/**
+ * statusManifest.js
+ *
+ * PR-5b-i (observability). Turns DataService.lastSourceStatuses into a
+ * machine-readable health manifest + a GitHub Actions step summary, so a green
+ * build can no longer hide a configured source that quietly fell back.
+ *
+ * Classification (the axis that matters for alerting):
+ *   - 'live'     — ok with data (configured + succeeded)
+ *   - 'skip'     — ok({}) intentional skip (disabled/unconfigured) → NEVER alerts
+ *   - 'fallback' — default served but a failure occurred → alerts
+ *   - 'error'    — no usable value → alerts
+ *
+ * 'skip' vs 'live' is only knowable where the value exists, so classifySource()
+ * is applied at the DataService capture seam; the raw value is never carried
+ * into the manifest (it only ever holds normalized, log-safe errors).
+ */
+
+const HIGH_SIGNAL_STATUSES = new Set([401, 403, 429])
+const FAILURE = new Set(['fallback', 'error'])
+
+const ICON = { live: '✅', skip: '⏭️', fallback: '⚠️', error: '⛔' }
+
+function hasData(value) {
+  return value != null && typeof value === 'object' && Object.keys(value).length > 0
+}
+
+/**
+ * Label a single discriminated source result. Called at capture time (value in
+ * scope) so an intentional ok({}) skip is distinguishable from live ok(data).
+ * @param {{ status?: string, value?: unknown } | null | undefined} result
+ * @returns {'live'|'skip'|'fallback'|'error'}
+ */
+export function classifySource(result) {
+  if (!result || typeof result.status !== 'string') return 'error'
+  if (result.status === 'ok') return hasData(result.value) ? 'live' : 'skip'
+  if (result.status === 'fallback') return 'fallback'
+  return 'error'
+}
+
+function isHighSignal(classification, error) {
+  return FAILURE.has(classification) && HIGH_SIGNAL_STATUSES.has(error?.status)
+}
+
+/**
+ * Build the machine-readable status manifest from the per-source statuses
+ * DataService records (each already classified at capture).
+ * @param {Array<{source:string,status:string,classification:string,error:object|null}>} statuses
+ * @param {{ generatedAt?: number }} [opts]
+ */
+export function buildStatusManifest(statuses = [], { generatedAt = Date.now() } = {}) {
+  const sources = statuses.map((entry) => ({
+    source: entry.source,
+    classification: entry.classification,
+    status: entry.status,
+    highSignal: isHighSignal(entry.classification, entry.error),
+    error: entry.error ?? null,
+  }))
+
+  const countOf = (c) => sources.filter((s) => s.classification === c).length
+  const summary = {
+    total: sources.length,
+    live: countOf('live'),
+    skip: countOf('skip'),
+    fallback: countOf('fallback'),
+    error: countOf('error'),
+    highSignal: sources.filter((s) => s.highSignal).length,
+    alerting: sources.some((s) => FAILURE.has(s.classification)),
+  }
+
+  return { generatedAt, sources, summary }
+}
+
+function noteFor(source) {
+  if (!source.error) return ''
+  const base = source.error.status ? `HTTP ${source.error.status}` : source.error.message
+  return source.highSignal ? `${base} (auth/rate-limit, high-signal)` : base
+}
+
+/**
+ * Render the manifest as GitHub Actions step-summary markdown.
+ * @param {ReturnType<typeof buildStatusManifest>} manifest
+ * @returns {string}
+ */
+export function renderStepSummary(manifest) {
+  const { sources, summary } = manifest
+
+  const rows = sources
+    .map((s) => `| ${s.source} | ${ICON[s.classification]} ${s.classification} | ${noteFor(s)} |`)
+    .join('\n')
+
+  const headline = summary.alerting
+    ? `⚠️ ${summary.fallback + summary.error} configured source(s) failing` +
+      (summary.highSignal ? ` — ${summary.highSignal} high-signal (auth/rate-limit)` : '')
+    : '✅ All configured sources healthy — no alert'
+
+  return [
+    '## ProfileChatter source status',
+    '',
+    '| Source | Status | Note |',
+    '| --- | --- | --- |',
+    rows,
+    '',
+    `**${summary.total} sources** — ${summary.live} live, ${summary.skip} skip, ` +
+      `${summary.fallback} fallback, ${summary.error} error.`,
+    '',
+    headline,
+    '',
+  ].join('\n')
+}

--- a/src/services/utils/statusManifest.test.js
+++ b/src/services/utils/statusManifest.test.js
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest'
-import { classifySource, buildStatusManifest, renderStepSummary } from './statusManifest.js'
+import { describe, it, expect, vi } from 'vitest'
+import {
+  classifySource,
+  buildStatusManifest,
+  renderStepSummary,
+  emitStatusManifest,
+} from './statusManifest.js'
 import { ok, fallback, errored } from './sourceResult.js'
 import { HttpError } from './httpClient.js'
 
@@ -157,5 +162,50 @@ describe('renderStepSummary (GitHub Actions markdown)', () => {
     const clean = [statusEntry({ source: 'github', classification: 'live' })]
     const md = renderStepSummary(buildStatusManifest(clean, { generatedAt: 1 }))
     expect(md).toMatch(/no .*alert|healthy/i)
+  })
+})
+
+describe('emitStatusManifest', () => {
+  const deps = () => ({ writeFile: vi.fn(), appendFile: vi.fn() })
+
+  it('writes the manifest as pretty JSON and returns it', () => {
+    const { writeFile, appendFile } = deps()
+    const manifest = emitStatusManifest(MIXED, {
+      generatedAt: 5,
+      manifestPath: 'dist/status-manifest.json',
+      writeFile,
+      appendFile,
+    })
+    expect(writeFile).toHaveBeenCalledTimes(1)
+    const [path, contents] = writeFile.mock.calls[0]
+    expect(path).toBe('dist/status-manifest.json')
+    expect(JSON.parse(contents)).toEqual(manifest)
+    expect(manifest.generatedAt).toBe(5)
+  })
+
+  it('appends the step summary when a step-summary path is provided (CI)', () => {
+    const { writeFile, appendFile } = deps()
+    emitStatusManifest(MIXED, {
+      generatedAt: 5,
+      manifestPath: 'dist/status-manifest.json',
+      stepSummaryPath: '/gh/step-summary',
+      writeFile,
+      appendFile,
+    })
+    expect(appendFile).toHaveBeenCalledTimes(1)
+    const [path, markdown] = appendFile.mock.calls[0]
+    expect(path).toBe('/gh/step-summary')
+    expect(markdown).toContain('ProfileChatter source status')
+  })
+
+  it('does not append a step summary when no path is set (local build)', () => {
+    const { writeFile, appendFile } = deps()
+    emitStatusManifest(MIXED, {
+      generatedAt: 5,
+      manifestPath: 'dist/status-manifest.json',
+      writeFile,
+      appendFile,
+    })
+    expect(appendFile).not.toHaveBeenCalled()
   })
 })

--- a/src/services/utils/statusManifest.test.js
+++ b/src/services/utils/statusManifest.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import { classifySource, buildStatusManifest, renderStepSummary } from './statusManifest.js'
+import { ok, fallback, errored } from './sourceResult.js'
+import { HttpError } from './httpClient.js'
+
+describe('classifySource', () => {
+  it("labels an ok result carrying data as 'live'", () => {
+    expect(classifySource(ok({ githubFollowers: '48' }))).toBe('live')
+  })
+
+  it("labels an ok result with an empty value (intentional skip) as 'skip'", () => {
+    expect(classifySource(ok({}))).toBe('skip')
+  })
+
+  it("labels an ok result with no value at all as 'skip'", () => {
+    expect(classifySource(ok())).toBe('skip')
+  })
+
+  it("labels a fallback result as 'fallback'", () => {
+    expect(classifySource(fallback({ x: 1 }, new HttpError(401, 'Unauthorized')))).toBe('fallback')
+  })
+
+  it("labels an errored result as 'error'", () => {
+    expect(classifySource(errored(new Error('boom')))).toBe('error')
+  })
+
+  it("treats a missing or malformed result defensively as 'error'", () => {
+    expect(classifySource(null)).toBe('error')
+    expect(classifySource({ status: 'weird' })).toBe('error')
+  })
+})
+
+// Statuses as DataService records them after enrichment: classification is derived
+// once (at capture, where the value exists) and the raw value is never carried here.
+const statusEntry = (over) => ({
+  source: 'github',
+  status: 'ok',
+  classification: 'live',
+  error: null,
+  fetchedAt: 10,
+  ...over,
+})
+
+const MIXED = [
+  statusEntry({ source: 'github', status: 'ok', classification: 'live', error: null }),
+  statusEntry({ source: 'weather', status: 'ok', classification: 'skip', error: null }),
+  statusEntry({
+    source: 'githubOAuth',
+    status: 'fallback',
+    classification: 'fallback',
+    error: { message: 'Unauthorized', status: 401 },
+  }),
+  statusEntry({
+    source: 'wakatime',
+    status: 'error',
+    classification: 'error',
+    error: { message: 'Service Unavailable', status: 503 },
+  }),
+  statusEntry({
+    source: 'codestats',
+    status: 'fallback',
+    classification: 'fallback',
+    error: { message: 'network down' }, // transient, no HTTP status
+  }),
+]
+
+describe('buildStatusManifest', () => {
+  it('stamps generatedAt and summarizes classification counts', () => {
+    const m = buildStatusManifest(MIXED, { generatedAt: 123 })
+    expect(m.generatedAt).toBe(123)
+    expect(m.summary).toMatchObject({ total: 5, live: 1, skip: 1, fallback: 2, error: 1 })
+  })
+
+  it('flags 401/403/429 failures as high-signal auth/rate-limit', () => {
+    const m = buildStatusManifest(MIXED, { generatedAt: 123 })
+    expect(m.sources.find((s) => s.source === 'githubOAuth').highSignal).toBe(true)
+    expect(m.summary.highSignal).toBe(1)
+  })
+
+  it('does not flag a non-auth failure (503) or a status-less failure as high-signal', () => {
+    const m = buildStatusManifest(MIXED, { generatedAt: 123 })
+    expect(m.sources.find((s) => s.source === 'wakatime').highSignal).toBe(false)
+    expect(m.sources.find((s) => s.source === 'codestats').highSignal).toBe(false)
+  })
+
+  it('alerts when any configured source failed (fallback/error)', () => {
+    const m = buildStatusManifest(MIXED, { generatedAt: 123 })
+    expect(m.summary.alerting).toBe(true)
+  })
+
+  it('does not alert when only live and skip sources are present', () => {
+    const clean = [
+      statusEntry({ source: 'github', classification: 'live' }),
+      statusEntry({ source: 'weather', classification: 'skip', error: null }),
+    ]
+    const m = buildStatusManifest(clean, { generatedAt: 123 })
+    expect(m.summary.alerting).toBe(false)
+    expect(m.summary).toMatchObject({ total: 2, live: 1, skip: 1, fallback: 0, error: 0 })
+  })
+
+  it('publishes only normalized errors per source — no raw values, safe to commit/upload', () => {
+    const m = buildStatusManifest(MIXED, { generatedAt: 123 })
+    expect(m.sources.find((s) => s.source === 'githubOAuth')).toEqual({
+      source: 'githubOAuth',
+      classification: 'fallback',
+      status: 'fallback',
+      highSignal: true,
+      error: { message: 'Unauthorized', status: 401 },
+    })
+    expect(m.sources.find((s) => s.source === 'github')).toEqual({
+      source: 'github',
+      classification: 'live',
+      status: 'ok',
+      highSignal: false,
+      error: null,
+    })
+  })
+})
+
+describe('renderStepSummary (GitHub Actions markdown)', () => {
+  it('lists every source with its classification', () => {
+    const md = renderStepSummary(buildStatusManifest(MIXED, { generatedAt: 123 }))
+    for (const name of ['github', 'weather', 'githubOAuth', 'wakatime', 'codestats']) {
+      expect(md).toContain(name)
+    }
+    expect(md).toMatch(/skip/i)
+    expect(md).toMatch(/fallback/i)
+  })
+
+  it('surfaces high-signal auth/rate-limit failures with their HTTP status', () => {
+    const md = renderStepSummary(buildStatusManifest(MIXED, { generatedAt: 123 }))
+    expect(md).toContain('HTTP 401')
+    expect(md).toMatch(/high.?signal/i)
+  })
+
+  it('shows the status-less failure by its message, not a phantom HTTP code', () => {
+    const md = renderStepSummary(buildStatusManifest(MIXED, { generatedAt: 123 }))
+    expect(md).toContain('network down')
+  })
+
+  it('reports a configured failure but omits the high-signal note when none are auth/rate-limit', () => {
+    const only503 = [
+      statusEntry({ source: 'github', classification: 'live' }),
+      statusEntry({
+        source: 'wakatime',
+        status: 'error',
+        classification: 'error',
+        error: { message: 'Service Unavailable', status: 503 },
+      }),
+    ]
+    const md = renderStepSummary(buildStatusManifest(only503, { generatedAt: 1 }))
+    expect(md).toMatch(/configured source\(s\) failing/i)
+    expect(md).not.toMatch(/high.?signal/i)
+  })
+
+  it('states clearly when all configured sources are healthy', () => {
+    const clean = [statusEntry({ source: 'github', classification: 'live' })]
+    const md = renderStepSummary(buildStatusManifest(clean, { generatedAt: 1 }))
+    expect(md).toMatch(/no .*alert|healthy/i)
+  })
+})

--- a/tests/unit/services/__tests__/DataService.test.js
+++ b/tests/unit/services/__tests__/DataService.test.js
@@ -223,6 +223,44 @@ describe('DataService', () => {
       expect(bySource.githubOAuth.status).toBe('ok')
     })
 
+    it('records a classification per source (live / skip / fallback) for the status manifest', async () => {
+      // An intentional ok({}) skip must be distinguishable from live ok(data) and
+      // from a configured fallback — the manifest is built off this classification.
+      getWeatherData.mockResolvedValue({ status: 'ok', value: {}, fetchedAt: 1 }) // skip
+      getGitHubData.mockResolvedValue({
+        status: 'ok',
+        value: { githubFollowers: '5' },
+        fetchedAt: 1,
+      }) // live
+      getWakaTimeData.mockResolvedValue({
+        status: 'ok',
+        value: { wakatime_summary: 'x' },
+        fetchedAt: 1,
+      })
+      getTwitterData.mockResolvedValue({ status: 'ok', value: {}, fetchedAt: 1 }) // skip
+      getCodeStatsData.mockResolvedValue({
+        status: 'ok',
+        value: { codestatsXP: '9' },
+        fetchedAt: 1,
+      })
+      getSpotifyData.mockResolvedValue({ status: 'ok', value: { spotifyTrack: 'x' }, fetchedAt: 1 })
+      getGitHubOAuthData.mockResolvedValue({
+        status: 'fallback',
+        value: { githubTotalStars: '0' },
+        error: { message: 'Unauthorized', status: 401 },
+        fetchedAt: 1,
+      })
+
+      await DataService.getDynamicData()
+
+      const bySource = Object.fromEntries(DataService.lastSourceStatuses.map((s) => [s.source, s]))
+      expect(bySource.weather.classification).toBe('skip')
+      expect(bySource.github.classification).toBe('live')
+      expect(bySource.wakatime.classification).toBe('live')
+      expect(bySource.twitter.classification).toBe('skip')
+      expect(bySource.githubOAuth.classification).toBe('fallback')
+    })
+
     it('resets source statuses each run (no stale leak when a later run fails early)', async () => {
       // Run 1: populate statuses with a github fallback.
       getWeatherData.mockResolvedValue({})


### PR DESCRIPTION
## PR-5b-i: source status manifest (observability)

**User impact:** every build now emits a per-source health manifest + a GitHub
Actions step summary, so a green build can no longer silently hide a configured
source that fell back to defaults. Intentional skips (e.g. weather with no key,
manual Twitter) are classified as skips and never alarm.

**Risk removed:** the "green build, invisible fallback" failure mode that caused the
stale-stats incident is now visible on every run.

**Scope (observability only):** classification (live/skip/fallback/error) recorded at
the DataService capture seam; manifest builder + Actions step summary; 401/403/429
flagged high-signal; `dist/status-manifest.json` uploaded as an artifact. No source
behavior changes, no alerting/issue creation (that's PR-5b-ii), no weather/provider
or GraphQL changes.

**Test proof:** 467 passing; `statusManifest.js` 100% stmts/branches/funcs/lines;
`npm run verify` green (94/86/98.5/94 vs 85/80/95/85 floors). TDD: RED→GREEN per increment.
No mutation tooling in the repo (no Stryker), so no formal MUTATE pass — compensated with
100% branch coverage and behavior-asserting tests.

**Manual verification:** real local build emitted `dist/status-manifest.json` + the step
summary; twitter→skip (non-alerting), weather/githubOAuth 401→fallback high-signal.

**Note on classification being environment-specific:** the manual run above reflects the
*local* environment's secrets. CI/prod will classify different sources depending on which
secrets are present (e.g. in CI weather is an intentional skip and githubOAuth is live).
That variability is expected — it is exactly why the manifest exists: it reports the truth
of each run rather than assuming it.

**Follow-up:** #23 (unconfigured Spotify/GitHub-OAuth → intentional skip).
