### PR TITLE
feat(reliability): status-alert reconciliation — alerting (PR-5b-ii)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ on:
 
 permissions:
   contents: write
+  issues: write # PR-5b-ii: status-alert reconciler opens/updates/closes one stable issue
 
 env:
   NODE_VERSION: '24'
@@ -67,6 +68,18 @@ jobs:
           PAT_GITHUB_OAUTH: ${{ secrets.PAT_GITHUB_OAUTH }}
           GITHUB_DATA_MODE: 'ci'
         run: node src/build-profile.js
+
+      # PR-5b-ii: monitoring sidecar. Reconciles ONE stable status-alert issue
+      # from dist/status-manifest.json. Non-PR only (PRs must never touch issues).
+      # continue-on-error so a transient Issues-API problem is shown red but never
+      # blocks the SVG build/commit; the step itself writes a loud summary note.
+      - name: Reconcile status alert
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node src/report-status-alert.js
 
       - name: Record timestamp
         id: ts

--- a/src/report-status-alert.js
+++ b/src/report-status-alert.js
@@ -1,0 +1,27 @@
+/**
+ * report-status-alert.js
+ *
+ * Thin CI entry for PR-5b-ii alerting (coverage-excluded glue). Wires real
+ * fs / env / fetch into runStatusAlert, then exits non-zero on a reconcile
+ * failure so the (continue-on-error) workflow step shows red and writes a
+ * step-summary note — visible, but never blocking the SVG build/commit.
+ */
+import { readFileSync, existsSync, appendFileSync } from 'node:fs'
+import { runStatusAlert } from './services/alerting/runStatusAlert.js'
+import { createGitHubIssues } from './services/alerting/githubIssues.js'
+
+const manifestPath = 'dist/status-manifest.json'
+
+const result = await runStatusAlert({
+  readManifest: () =>
+    existsSync(manifestPath) ? JSON.parse(readFileSync(manifestPath, 'utf8')) : null,
+  env: process.env,
+  fetchImpl: fetch,
+  logger: console,
+  appendSummary: (text) => {
+    if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, text)
+  },
+  makeIssues: createGitHubIssues,
+})
+
+if (!result.ok) process.exit(1)

--- a/src/services/alerting/githubIssues.js
+++ b/src/services/alerting/githubIssues.js
@@ -1,0 +1,65 @@
+/**
+ * githubIssues.js
+ *
+ * Thin GitHub REST adapter implementing the `issues` port the reconciler needs
+ * (findOpenAlert / create / comment / close). `fetchImpl` is injected so the
+ * request contract is unit-tested without any live network call. Failures throw
+ * with the HTTP status so the workflow step fails loudly rather than silently.
+ */
+
+/**
+ * @param {{ repo: string, token: string, fetchImpl: typeof fetch }} cfg
+ *   repo is "owner/name"; token needs issues:write.
+ */
+export function createGitHubIssues({ repo, token, fetchImpl }) {
+  const base = `https://api.github.com/repos/${repo}`
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'profilechatter-status-bot',
+  }
+
+  async function call(url, init, what) {
+    const res = await fetchImpl(url, { headers, ...init })
+    if (!res.ok) throw new Error(`GitHub ${what} failed: HTTP ${res.status}`)
+    return res
+  }
+
+  return {
+    async findOpenAlert(marker) {
+      const res = await call(`${base}/issues?state=open&per_page=100`, {}, 'list issues')
+      const issues = await res.json()
+      const found = issues.find(
+        (i) => !i.pull_request && typeof i.body === 'string' && i.body.includes(marker)
+      )
+      return found ? { number: found.number, body: found.body } : null
+    },
+
+    async create({ title, body }) {
+      const res = await call(
+        `${base}/issues`,
+        { method: 'POST', body: JSON.stringify({ title, body }) },
+        'create issue'
+      )
+      const json = await res.json()
+      return { number: json.number }
+    },
+
+    async comment(number, body) {
+      await call(
+        `${base}/issues/${number}/comments`,
+        { method: 'POST', body: JSON.stringify({ body }) },
+        'comment'
+      )
+    },
+
+    async close(number) {
+      await call(
+        `${base}/issues/${number}`,
+        { method: 'PATCH', body: JSON.stringify({ state: 'closed' }) },
+        'close issue'
+      )
+    },
+  }
+}

--- a/src/services/alerting/githubIssues.test.js
+++ b/src/services/alerting/githubIssues.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createGitHubIssues } from './githubIssues.js'
+
+const res = (body, { ok = true, status = 200 } = {}) => ({ ok, status, json: async () => body })
+const make = (fetchImpl) => createGitHubIssues({ repo: 'me/repo', token: 'T', fetchImpl })
+
+describe('createGitHubIssues adapter', () => {
+  it('findOpenAlert returns the open issue whose body holds the marker (PRs and body-less issues ignored)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      res([
+        { number: 1, body: 'unrelated' },
+        { number: 2, body: `x MARKER y`, pull_request: {} }, // a PR — ignore
+        { number: 4, body: null }, // body-less — ignore
+        { number: 3, body: 'has MARKER here' },
+      ])
+    )
+    const found = await make(fetchImpl).findOpenAlert('MARKER')
+    expect(found).toEqual({ number: 3, body: 'has MARKER here' })
+    const [url, opts] = fetchImpl.mock.calls[0]
+    expect(url).toContain('/repos/me/repo/issues')
+    expect(url).toContain('state=open')
+    expect(opts.headers.Authorization).toBe('Bearer T')
+  })
+
+  it('findOpenAlert returns null when no open issue carries the marker', async () => {
+    expect(
+      await make(vi.fn().mockResolvedValue(res([{ number: 1, body: 'nope' }]))).findOpenAlert(
+        'MARKER'
+      )
+    ).toBeNull()
+  })
+
+  it('create POSTs title/body and returns the new number', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(res({ number: 42 }, { status: 201 }))
+    const out = await make(fetchImpl).create({ title: 'T', body: 'B' })
+    expect(out).toEqual({ number: 42 })
+    const [url, opts] = fetchImpl.mock.calls[0]
+    expect(url).toBe('https://api.github.com/repos/me/repo/issues')
+    expect(opts.method).toBe('POST')
+    expect(JSON.parse(opts.body)).toEqual({ title: 'T', body: 'B' })
+  })
+
+  it('comment POSTs to the issue comments endpoint', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(res({}, { status: 201 }))
+    await make(fetchImpl).comment(7, 'hi')
+    const [url, opts] = fetchImpl.mock.calls[0]
+    expect(url).toBe('https://api.github.com/repos/me/repo/issues/7/comments')
+    expect(opts.method).toBe('POST')
+    expect(JSON.parse(opts.body)).toEqual({ body: 'hi' })
+  })
+
+  it('close PATCHes the issue state to closed', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(res({}, { status: 200 }))
+    await make(fetchImpl).close(7)
+    const [url, opts] = fetchImpl.mock.calls[0]
+    expect(url).toBe('https://api.github.com/repos/me/repo/issues/7')
+    expect(opts.method).toBe('PATCH')
+    expect(JSON.parse(opts.body)).toEqual({ state: 'closed' })
+  })
+
+  it('throws with the HTTP status on a failed call (so the workflow step fails loudly)', async () => {
+    await expect(
+      make(vi.fn().mockResolvedValue(res({}, { ok: false, status: 403 }))).create({
+        title: 'T',
+        body: 'B',
+      })
+    ).rejects.toThrow(/403/)
+  })
+})

--- a/src/services/alerting/runStatusAlert.js
+++ b/src/services/alerting/runStatusAlert.js
@@ -1,0 +1,56 @@
+/**
+ * runStatusAlert.js
+ *
+ * Orchestrates PR-5b-ii alerting between the emitted manifest and GitHub Issues.
+ * Kept separate from the thin entry script (src/report-status-alert.js) so every
+ * branch — missing manifest, no credentials, reconcile, and API failure — is
+ * unit-tested with injected deps (no fs/network/process here).
+ *
+ * Alerting is a monitoring sidecar, NOT the product delivery path: a GitHub
+ * Issues API failure is reported loudly (::error:: annotation + step-summary
+ * note) and returned as { ok: false } so the caller can mark the step failed,
+ * but it never throws — the SVG build/commit must not be blocked by it.
+ */
+import { reconcileStatusAlert } from './statusAlertReconciler.js'
+
+/**
+ * @param {{
+ *   readManifest: () => object | null,
+ *   env: Record<string, string | undefined>,
+ *   fetchImpl: typeof fetch,
+ *   logger: { log: (m: string) => void, error: (m: string) => void },
+ *   appendSummary: (text: string) => void,
+ *   makeIssues: (cfg: { repo: string, token: string, fetchImpl: typeof fetch }) => object,
+ * }} deps
+ * @returns {Promise<{ ok: boolean, action?: string, issue?: number, reason?: string, error?: string }>}
+ */
+export async function runStatusAlert(deps) {
+  const { readManifest, env, fetchImpl, logger, appendSummary, makeIssues } = deps
+
+  const manifest = readManifest()
+  if (!manifest) {
+    logger.log('Status alert: no manifest found — nothing to reconcile.')
+    return { ok: true, action: 'none', reason: 'no-manifest' }
+  }
+
+  const repo = env.GITHUB_REPOSITORY
+  const token = env.GITHUB_TOKEN
+  if (!repo || !token) {
+    logger.log('Status alert: no GitHub token/repo — skipping reconciliation.')
+    return { ok: true, action: 'none', reason: 'no-credentials' }
+  }
+
+  try {
+    const issues = makeIssues({ repo, token, fetchImpl })
+    const result = await reconcileStatusAlert(manifest, issues)
+    logger.log(
+      `Status alert reconciliation: ${result.action}${result.issue ? ` (#${result.issue})` : ''}`
+    )
+    return { ok: true, ...result }
+  } catch (err) {
+    // Visible but non-blocking: loud annotation + step-summary note, no throw.
+    logger.error(`::error::Status alert reconciliation failed: ${err.message}`)
+    appendSummary(`\n> ⚠️ **Status alert reconciliation failed:** ${err.message}\n`)
+    return { ok: false, error: err.message }
+  }
+}

--- a/src/services/alerting/runStatusAlert.test.js
+++ b/src/services/alerting/runStatusAlert.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runStatusAlert } from './runStatusAlert.js'
+import { buildStatusManifest } from '../utils/statusManifest.js'
+
+const alertingManifest = () =>
+  buildStatusManifest(
+    [
+      {
+        source: 'githubOAuth',
+        status: 'fallback',
+        classification: 'fallback',
+        error: { message: 'Unauthorized', status: 401 },
+        fetchedAt: 1,
+      },
+    ],
+    { generatedAt: 1700000000000 }
+  )
+
+const healthyManifest = () =>
+  buildStatusManifest(
+    [{ source: 'github', status: 'ok', classification: 'live', error: null, fetchedAt: 1 }],
+    { generatedAt: 1 }
+  )
+
+const port = (over = {}) => ({
+  findOpenAlert: vi.fn().mockResolvedValue(null),
+  create: vi.fn().mockResolvedValue({ number: 99 }),
+  comment: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+  ...over,
+})
+
+const baseDeps = (over = {}) => ({
+  readManifest: () => healthyManifest(),
+  env: { GITHUB_TOKEN: 'T', GITHUB_REPOSITORY: 'me/repo' },
+  fetchImpl: vi.fn(),
+  logger: { log: vi.fn(), error: vi.fn() },
+  appendSummary: vi.fn(),
+  makeIssues: vi.fn().mockReturnValue(port()),
+  ...over,
+})
+
+describe('runStatusAlert', () => {
+  it('no-ops when the manifest file is missing (never touches GitHub)', async () => {
+    const makeIssues = vi.fn()
+    const res = await runStatusAlert(baseDeps({ readManifest: () => null, makeIssues }))
+    expect(res).toMatchObject({ ok: true, action: 'none', reason: 'no-manifest' })
+    expect(makeIssues).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when no GitHub token/repo is available (local runs)', async () => {
+    const makeIssues = vi.fn()
+    const res = await runStatusAlert(baseDeps({ env: {}, makeIssues }))
+    expect(res).toMatchObject({ ok: true, action: 'none', reason: 'no-credentials' })
+    expect(makeIssues).not.toHaveBeenCalled()
+  })
+
+  it('creates the issue for an alerting manifest and reports the action', async () => {
+    const issues = port()
+    const makeIssues = vi.fn().mockReturnValue(issues)
+    const logger = { log: vi.fn(), error: vi.fn() }
+    const res = await runStatusAlert(
+      baseDeps({ readManifest: () => alertingManifest(), makeIssues, logger })
+    )
+    expect(res).toMatchObject({ ok: true, action: 'created', issue: 99 })
+    expect(makeIssues).toHaveBeenCalledWith({
+      repo: 'me/repo',
+      token: 'T',
+      fetchImpl: expect.any(Function),
+    })
+    expect(issues.create).toHaveBeenCalledTimes(1)
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('created'))
+  })
+
+  it('reconciles a healthy manifest to a no-op when nothing is open', async () => {
+    const issues = port()
+    const res = await runStatusAlert(
+      baseDeps({
+        readManifest: () => healthyManifest(),
+        makeIssues: vi.fn().mockReturnValue(issues),
+      })
+    )
+    expect(res).toMatchObject({ ok: true, action: 'none' })
+    expect(issues.create).not.toHaveBeenCalled()
+  })
+
+  it('on a GitHub API failure: returns not-ok, logs an ::error::, and notes it in the step summary (never throws)', async () => {
+    const issues = port({ findOpenAlert: vi.fn().mockRejectedValue(new Error('HTTP 403')) })
+    const logger = { log: vi.fn(), error: vi.fn() }
+    const appendSummary = vi.fn()
+    const res = await runStatusAlert(
+      baseDeps({
+        readManifest: () => alertingManifest(),
+        makeIssues: vi.fn().mockReturnValue(issues),
+        logger,
+        appendSummary,
+      })
+    )
+    expect(res.ok).toBe(false)
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('::error::'))
+    expect(appendSummary).toHaveBeenCalledWith(expect.stringMatching(/reconciliation failed/i))
+  })
+})

--- a/src/services/alerting/statusAlertReconciler.js
+++ b/src/services/alerting/statusAlertReconciler.js
@@ -1,0 +1,94 @@
+/**
+ * statusAlertReconciler.js
+ *
+ * PR-5b-ii (alerting). Reconciles a single, stable GitHub issue against the
+ * status manifest so a *configured* source failure is surfaced loudly and
+ * recovery clears it — without issue spam and without any persisted counter.
+ *
+ *   alerting + no open issue   → create one (carries a hidden marker)
+ *   alerting + open issue      → comment "still failing" on it (no duplicate)
+ *   healthy  + open issue      → comment "recovered", then close it (audit trail)
+ *   healthy  + no open issue   → do nothing
+ *
+ * Intentional ok({}) skips never set manifest.summary.alerting, so they never
+ * alarm. Pure logic over an injected `issues` port (findOpenAlert/create/
+ * comment/close) so every path is deterministically unit-tested.
+ */
+import { renderStepSummary } from '../utils/statusManifest.js'
+
+// Hidden HTML-comment marker used to find the one managed issue idempotently.
+export const ALERT_MARKER = '<!-- profilechatter:status-alert:v1 -->'
+
+const failingSources = (manifest) =>
+  manifest.sources.filter((s) => s.classification === 'fallback' || s.classification === 'error')
+
+const isoOf = (ms) => new Date(ms).toISOString()
+
+const highSignalSuffix = (manifest) =>
+  manifest.summary.highSignal
+    ? ` (${manifest.summary.highSignal} high-signal — auth/rate-limit)`
+    : ''
+
+function alertTitle(manifest) {
+  const n = manifest.summary.fallback + manifest.summary.error
+  return `⚠️ ProfileChatter: ${n} data source(s) failing`
+}
+
+export function renderAlertBody(manifest) {
+  return [
+    ALERT_MARKER,
+    '## ProfileChatter source alert',
+    '',
+    `As of \`${isoOf(manifest.generatedAt)}\`, one or more **configured** sources are failing.`,
+    'Intentional skips (disabled/unconfigured integrations) are not counted.' +
+      highSignalSuffix(manifest),
+    '',
+    renderStepSummary(manifest),
+    '---',
+    '_Auto-managed: this issue updates on continued failure and closes on recovery._',
+    '',
+  ].join('\n')
+}
+
+export function renderContinuingComment(manifest) {
+  const names = failingSources(manifest)
+    .map((s) => s.source)
+    .join(', ')
+  return `Still failing as of \`${isoOf(manifest.generatedAt)}\` — ${names}.${highSignalSuffix(manifest)}`
+}
+
+export function renderRecoveryComment(manifest) {
+  return `✅ Recovered — all configured sources healthy as of \`${isoOf(manifest.generatedAt)}\`. Closing this alert.`
+}
+
+/**
+ * @param {ReturnType<import('../utils/statusManifest.js').buildStatusManifest>} manifest
+ * @param {{ findOpenAlert(marker:string):Promise<{number:number,body:string}|null>,
+ *           create(arg:{title:string,body:string}):Promise<{number:number}>,
+ *           comment(number:number, body:string):Promise<void>,
+ *           close(number:number):Promise<void> }} issues
+ * @returns {Promise<{action:'created'|'updated'|'resolved'|'none', issue?:number}>}
+ */
+export async function reconcileStatusAlert(manifest, issues) {
+  const existing = await issues.findOpenAlert(ALERT_MARKER)
+
+  if (manifest.summary.alerting) {
+    if (existing) {
+      await issues.comment(existing.number, renderContinuingComment(manifest))
+      return { action: 'updated', issue: existing.number }
+    }
+    const created = await issues.create({
+      title: alertTitle(manifest),
+      body: renderAlertBody(manifest),
+    })
+    return { action: 'created', issue: created.number }
+  }
+
+  if (existing) {
+    await issues.comment(existing.number, renderRecoveryComment(manifest))
+    await issues.close(existing.number)
+    return { action: 'resolved', issue: existing.number }
+  }
+
+  return { action: 'none' }
+}

--- a/src/services/alerting/statusAlertReconciler.test.js
+++ b/src/services/alerting/statusAlertReconciler.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import { reconcileStatusAlert, ALERT_MARKER } from './statusAlertReconciler.js'
+import { buildStatusManifest } from '../utils/statusManifest.js'
+
+const entry = (over) => ({
+  source: 'github',
+  status: 'ok',
+  classification: 'live',
+  error: null,
+  fetchedAt: 1,
+  ...over,
+})
+
+// Alerting because a CONFIGURED source failed; weather skip must NOT count.
+const alerting401 = () =>
+  buildStatusManifest(
+    [
+      entry({ source: 'github', classification: 'live' }),
+      entry({ source: 'weather', classification: 'skip' }),
+      entry({
+        source: 'githubOAuth',
+        status: 'fallback',
+        classification: 'fallback',
+        error: { message: 'Unauthorized', status: 401 },
+      }),
+    ],
+    { generatedAt: 1700000000000 }
+  )
+
+// Alerting, but a non-auth outage (503) — not high-signal.
+const alerting503 = () =>
+  buildStatusManifest(
+    [
+      entry({ source: 'github', classification: 'live' }),
+      entry({
+        source: 'wakatime',
+        status: 'error',
+        classification: 'error',
+        error: { message: 'Service Unavailable', status: 503 },
+      }),
+    ],
+    { generatedAt: 1700000200000 }
+  )
+
+const healthy = () =>
+  buildStatusManifest(
+    [
+      entry({ source: 'github', classification: 'live' }),
+      entry({ source: 'weather', classification: 'skip' }),
+    ],
+    { generatedAt: 1700000100000 }
+  )
+
+// Fake issues port: records calls and models a single open alert issue.
+function fakeIssues(initial = null) {
+  const calls = []
+  let open = initial
+  let next = 101
+  return {
+    calls,
+    async findOpenAlert(marker) {
+      calls.push({ fn: 'findOpenAlert', marker })
+      return open
+    },
+    async create({ title, body }) {
+      calls.push({ fn: 'create', title, body })
+      open = { number: next, body }
+      return { number: next++ }
+    },
+    async comment(number, body) {
+      calls.push({ fn: 'comment', number, body })
+    },
+    async close(number) {
+      calls.push({ fn: 'close', number })
+      open = null
+    },
+  }
+}
+
+describe('reconcileStatusAlert', () => {
+  it('creates ONE issue carrying the hidden marker when alerting and none is open', async () => {
+    const issues = fakeIssues(null)
+    const res = await reconcileStatusAlert(alerting401(), issues)
+
+    expect(res).toMatchObject({ action: 'created' })
+    expect(issues.calls.filter((c) => c.fn === 'create')).toHaveLength(1)
+    const created = issues.calls.find((c) => c.fn === 'create')
+    expect(created.body).toContain(ALERT_MARKER)
+    expect(created.body).toContain('githubOAuth')
+    expect(created.body).toContain('HTTP 401')
+    expect(created.body).toMatch(/high.?signal/i)
+    // never leaks tokens/secrets/headers — only normalized error fields appear
+    expect(created.body).not.toMatch(/token|secret|authorization|bearer/i)
+  })
+
+  it('updates (comments on) the existing issue instead of creating a duplicate', async () => {
+    const issues = fakeIssues({ number: 7, body: `existing\n${ALERT_MARKER}` })
+    const res = await reconcileStatusAlert(alerting401(), issues)
+
+    expect(res).toMatchObject({ action: 'updated', issue: 7 })
+    expect(issues.calls.some((c) => c.fn === 'create')).toBe(false)
+    const comment = issues.calls.find((c) => c.fn === 'comment')
+    expect(comment.number).toBe(7)
+    expect(comment.body).toMatch(/still failing/i)
+    expect(comment.body).toMatch(/high.?signal/i)
+  })
+
+  it('comments without a high-signal note when the continuing failure is not auth/rate-limit', async () => {
+    const issues = fakeIssues({ number: 7, body: ALERT_MARKER })
+    await reconcileStatusAlert(alerting503(), issues)
+    const comment = issues.calls.find((c) => c.fn === 'comment')
+    expect(comment.body).not.toMatch(/high.?signal/i)
+  })
+
+  it('omits the high-signal callout in a new issue when the failure is not auth/rate-limit', async () => {
+    const issues = fakeIssues(null)
+    await reconcileStatusAlert(alerting503(), issues)
+    const created = issues.calls.find((c) => c.fn === 'create')
+    expect(created.body).not.toMatch(/high.?signal/i)
+  })
+
+  it('on recovery comments THEN closes the same issue (audit trail before close)', async () => {
+    const issues = fakeIssues({ number: 7, body: ALERT_MARKER })
+    const res = await reconcileStatusAlert(healthy(), issues)
+
+    expect(res).toMatchObject({ action: 'resolved', issue: 7 })
+    const seq = issues.calls.filter((c) => c.fn === 'comment' || c.fn === 'close').map((c) => c.fn)
+    expect(seq).toEqual(['comment', 'close'])
+    const comment = issues.calls.find((c) => c.fn === 'comment')
+    expect(comment.body).toMatch(/recovered/i)
+  })
+
+  it('does nothing when healthy and no alert issue is open', async () => {
+    const issues = fakeIssues(null)
+    const res = await reconcileStatusAlert(healthy(), issues)
+
+    expect(res).toEqual({ action: 'none' })
+    expect(issues.calls.filter((c) => c.fn !== 'findOpenAlert')).toHaveLength(0)
+  })
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
       exclude: [
         'src/main.js',
         'src/build-profile.js',
+        'src/report-status-alert.js', // thin CI entry glue; logic lives in runStatusAlert.js
         'src/config/timezones.js', // Pure data
         'src/rendering/fontData.js', // Pure data
         'src/routes/**', // Express routes for OAuth, test via integration/e2e


### PR DESCRIPTION
## PR-5b-ii: status-alert reconciliation (alerting)

**User impact:** when a *configured* data source fails, ProfileChatter now opens a
single, stable GitHub issue and keeps it current; on recovery it comments and
closes that same issue. Maintainers get one clear, self-resolving signal instead
of silent stale data or alert spam. Intentional skips (disabled/unconfigured
integrations) never alarm.

**Risk removed:** the manifest from PR-5b-i was observable but passive — a real
configured failure still required someone to read the step summary. This makes a
configured failure actively surface as an issue, and clear itself on recovery.

**Scope (monitoring sidecar only):** a pure reconciler + a thin GitHub Issues REST
adapter + an orchestrator wired into `main.yml` after the SVG build. No source
behavior, SVG, GraphQL, or weather/provider changes. The GitHub issue itself is the
durable state — no committed counter, no state file.

**How it works:** one stable issue keyed by a hidden body marker
(`<!-- profilechatter:status-alert:v1 -->`):
- alerting + no open issue → create one (marker in body)
- alerting + open issue → comment "still failing" on it (no duplicate)
- healthy + open issue → comment "recovered", then close it (audit trail)
- healthy + no open issue → no-op

**Issue creation only runs on non-PR events** (`if: github.event_name != 'pull_request'`),
so this PR's own build will NOT create/update/close any issue. Uses the default
`${{ secrets.GITHUB_TOKEN }}` with `issues: write` — no new secret/PAT.

**continue-on-error is intentional:** alerting is a monitoring sidecar, not the
product-delivery path, so a transient GitHub Issues API problem must not block the
SVG build/commit. The failure is NOT silent: the step exits non-zero (shows red),
emits a `::error::` annotation, and writes a note to `$GITHUB_STEP_SUMMARY`.

**Test proof:** 23 alerting-path tests; the three logic modules
(`statusAlertReconciler`, `githubIssues`, `runStatusAlert`) are 100% on all metrics;
the entry script is the only excluded glue. `npm run verify` green. The alert /
upsert / recovery / no-op paths and the API-failure visibility path are proven
deterministically with **injected manifests and an injected fetch** — no real outage
is manufactured.

**Manual no-op proof:** running the entry locally with the manifest or credentials
absent logs "no manifest / no token" and exits 0 — no GitHub call, no issue created.

**Live CI expectation:** production is currently healthy, so the manifest is
`alerting=false`; the alert step will run on main and **no-op** (no issue created).
The reconciler ignores the existing follow-up issue #23 (it has no marker).

**Follow-up:** #23 (unconfigured Spotify/GitHub-OAuth → intentional skip) stays
separate; not in this PR.
