### PR TITLE
docs: Safe & reliable by design + ARCHITECTURE.md (PR-R4)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,77 @@
+# Architecture
+
+A short map of how ProfileChatter is put together, for contributors and maintainers. For setup and usage, see the [README](README.md).
+
+## Overview
+
+ProfileChatter has two halves:
+
+- **The generator** (`src/`, Node + ESM) — the unattended part that runs in GitHub Actions. It fetches live data, renders the animated SVG, and writes it to `dist/profile-chat.svg`. This is the load‑bearing product path.
+- **The Configurator** (`configurator-ui/`, Svelte + Vite) — a local, no‑code editor for messages, themes, avatars, and charts. It exports `profileChatterConfig.json` and ships a small local preview/OAuth server (`configurator-ui/server/`). It never runs in CI.
+
+## Build pipeline
+
+```
+main.js / build-profile.js
+  → ProfileChatter.generateChatSVG()
+      → DataService.getDynamicData()        // orchestrates all data sources in parallel
+          → services/data_sources/*.js      // each returns a discriminated result
+          → services/utils/httpClient.js    // shared fetch (timeout + retry, fail-fast 4xx)
+      → services/TimelineBuilder.js          // chatData + config → TimelineItem[]
+      → rendering/SvgRenderer.js             // timeline → animated SVG markup
+  → dist/profile-chat.svg
+```
+
+`.github/workflows/main.yml` runs this on a 6‑hour cron (and on relevant pushes), then commits the updated SVG back to the repo. `verify.yml` is the always‑on required check (lint + tests + Configurator build) on every PR.
+
+## Reliability spine
+
+The product promise is "set it once and your profile keeps talking," so the data layer's first job is to **never hide a failure**:
+
+- **`services/utils/httpClient.js`** — `fetchJson`: per‑attempt timeout, bounded retry/backoff for transient errors, fail‑fast on auth/config 4xx, normalized `HttpError`. `fetchImpl`/`sleep` are injectable for tests.
+- **`services/utils/sourceResult.js`** — the discriminated result each source returns: `ok` / `fallback` / `error`. An intentional skip (a disabled/unconfigured integration) is `ok({})`.
+- **`services/DataService.js`** — fetches all sources in parallel, unwraps values for rendering, and records per‑source health on `lastSourceStatuses` (reset each run, so a failed run can't leak prior health).
+- **`services/utils/statusManifest.js`** — classifies each source as **live / skip / fallback / error**, builds the machine‑readable manifest (`dist/status-manifest.json`) and the GitHub Actions step summary. Flags `401/403/429` as high‑signal.
+- **`services/alerting/`** — reconciles a single GitHub issue from the manifest: opens/updates while a configured source fails, comments and closes on recovery. The issue itself is the durable state (no committed counter); intentional skips never alert. Runs as a non‑PR‑gated, `continue-on-error` step so an Issues‑API hiccup never blocks the SVG build.
+
+## Configuration hierarchy
+
+Highest precedence wins:
+
+1. **`profileChatterConfig.json`** — exported by the Configurator UI; wins for the sections it contains.
+2. **`src/config/config.js`** — base defaults (themes, layout, profile, integration toggles).
+3. **`data/chatData.json`** — default chat messages when no config supplies a `chatMessages` array.
+
+## Security posture
+
+- **Preview server** (`configurator-ui/server/`) — binds to loopback by default, requires a server‑issued session token on state‑changing endpoints, and enforces strict CORS, a CSRF custom‑header requirement, payload schema validation, and a repo/path allow‑list on GitHub writes.
+- **Secrets** — all integrations are optional; tokens live in `.env` (local) or repository secrets (CI). The status manifest only ever carries normalized errors — never tokens, headers, or raw values.
+- **Commit‑back tokens** — the build commits the SVG using the owner PAT on the protected `main`, and falls back to the default `GITHUB_TOKEN` on forks (which have no branch protection), so a fresh fork works without a custom commit secret.
+
+## Testing & CI
+
+- **TDD** is the default: tests assert behavior through public APIs, not implementation.
+- `npm run verify` mirrors CI: ESLint + `vitest run --coverage` + the Configurator build.
+- The required `verify` check runs on every PR with coverage floors (statements 85 / branches 80 / functions 95 / lines 85). `main.yml` does the unattended build/commit and is path‑filtered to source/data.
+
+## Repo layout
+
+```
+src/
+  ProfileChatter.js, main.js, build-profile.js   # entry + orchestration
+  services/
+    DataService.js                               # source orchestration
+    data_sources/                                # the 7 sources
+    utils/        httpClient, sourceResult, statusManifest
+    alerting/     reconciler + GitHub adapter
+    auth/         OAuth services (GitHub, Spotify) + base
+  rendering/      SvgRenderer + components + animation engines
+  models/, config/, utils/
+configurator-ui/  Svelte editor + local server
+.github/workflows/  main.yml (build/commit), verify.yml (required gate)
+tests/unit/         the test suite
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). New backend code is TDD‑first and must keep `verify` green; new data sources should return discriminated results so they flow through the manifest/alerting layer automatically.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ Prefer to preview the default output without the UI? `npm run build` renders `di
 
 ---
 
+## 🛡️ Safe & reliable by design
+
+A profile widget is only worth embedding if you can trust it. ProfileChatter is built so it stays honest on its own:
+
+- **No hidden failures.** Each data source is fetched independently, and the build records whether it succeeded — so a green build can't silently show stale or made‑up data.
+- **Visible health every run.** The status manifest reports each source as **live / skip / fallback / error** in the Actions step summary (and `dist/status-manifest.json`).
+- **Self‑monitoring.** When a configured source keeps failing, ProfileChatter opens **one** GitHub issue and closes it on recovery — no spam.
+- **Honest numbers.** The "commits last year" value is the real GitHub contribution count, not a fabricated estimate.
+- **Intentional opt‑outs never false‑alarm.** Integrations you haven't set up are skipped, not treated as failures.
+- **Secure local tooling.** The Configurator's preview server binds to loopback and requires a session token plus strict CORS/CSRF checks.
+- **Tested & gated.** ~500 behavior‑asserting tests run on every PR behind a required CI check with coverage floors.
+
+For the deeper contributor/maintainer picture, see [ARCHITECTURE.md](ARCHITECTURE.md).
+
+---
+
 ## 🔌 Optional Integrations (add more live data)
 
 > **Everything here is optional.** ProfileChatter works with **no API keys** — these only add _more_ live data. Unconfigured integrations are skipped cleanly: they never error or show placeholder data. Configure any of them in the Configurator UI or as repository secrets.


### PR DESCRIPTION
## PR-R4: "Safe & reliable by design" + ARCHITECTURE.md

**User impact:** the README now surfaces *why the widget is trustworthy* — the
reliability work (discriminated results, status manifest, alerting, honest
numbers) becomes visible to anyone evaluating the project, without bloating the
README. Contributors/maintainers get a short, accurate architecture map.

**README:** a concise **🛡️ Safe & reliable by design** section immediately after
**🛠 How it Works** — seven trust bullets (no hidden failures · visible health ·
self-monitoring · honest numbers · opt-outs never false-alarm · secure local
tooling · tested & gated), linking to `ARCHITECTURE.md` for depth.

**ARCHITECTURE.md (new):** overview (generator + Configurator) · build pipeline ·
reliability spine · configuration hierarchy · security posture · testing & CI ·
repo layout. Short and credible, not a design-doc essay.

**Wording guard honored:** source states are described as what the **status
manifest reports** (live/skip/fallback/error), not equated with the internal
result-type names (`ok`/`fallback`/`error`).

**Accuracy:** claims are scoped to what's proven — ~500 tests (current count),
coverage floors 85/80/95/85, the actual security/alerting/commit-token behavior.

**Scope:** docs only — no code, no screenshots/GIFs, no troubleshooting expansion,
no dependency/currency work.

**Acceptance:** README trust section concise + renders cleanly; ARCHITECTURE.md
renders cleanly; the README→ARCHITECTURE.md link works; the doc reflects the repo;
no stale/exaggerated claims; `npm run verify` green.
