### PR TITLE
chore(release): prep v1.1.0 — changelog, manual QA, agnostic Spotify copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-12
+
 ### Added
 
 - Comprehensive backend unit and integration test suite (approx. 400+ tests)
@@ -17,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Issue Templates (bug_report.md, feature_request.md, showcase_submission.md)
 - Contribution Guide (CONTRIBUTING.md)
 - Integrated unit and integration tests into the GitHub Actions CI/CD pipeline
+- Reliability spine: every data source returns a discriminated result (ok / skip / fallback / error) so a green build can not silently show stale or fabricated data
+- Status manifest: machine-readable `dist/status-manifest.json` plus a GitHub Actions step summary classifying each source as live / skip / fallback / error
+- Self-healing alerting: a single GitHub issue auto-opens on a configured-source failure and closes on recovery (no spam, no committed state)
+- Honest GitHub contribution count via the GraphQL API (replaces the previous fabricated estimate)
+- Adaptive light/dark contrast: status text (Delivered/Read) and visitor bubble/text plus visitor-side chart surfaces now adapt to the viewer color scheme across iOS, Android, and Discord
+- Release-readiness docs: Troubleshooting, "Safe & reliable by design", ARCHITECTURE.md, and a success-first README funnel
+- README visual proof: a six-image theme gallery (light + dark) and refreshed Configurator screenshots
+- Fork-flow commit fallback: forks without the owner PAT auto-commit via `github.token`
 
 ### Changed
 
@@ -24,10 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved avatar handling in build-profile.js and AvatarSettingsEditor.svelte (URL prioritization, Base64 validation, local asset fallbacks)
 - Enhanced OAuth flow management in previewServer.js (Spotify & GitHub)
 - initConfigLoader.js now centralizes configuration loading logic for UI stores
+- Weather integration is now OFF by default (AccuWeather is trial/paid); opt in with a key
+- Unconfigured Spotify and GitHub-OAuth are treated as intentional skips, never fallbacks or false alarms
 
 ### Fixed
 
 - Critical bug where loading profileChatterConfig.json could reset UI state
 - Resolved issues with WORK_START_DATE updates not reflecting in UI previews
+- Spotify-skip copy now reads naturally when Spotify is unconfigured (no more "jamming to Not currently listening to music. right now")
+- Status text (Delivered/Read) was invisible (white-on-white) in light mode; it now adapts per color scheme
+- Visitor bubbles glared as light slabs in dark mode (iOS/Android) and appeared as dark blobs in light mode (Discord); they now adapt
 
-[Unreleased]: https://github.com/dsj7419/ProfileChatter/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/dsj7419/ProfileChatter/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/dsj7419/ProfileChatter/compare/v1.0.2...v1.1.0

--- a/MANUAL_QA_TEST_PLAN.md
+++ b/MANUAL_QA_TEST_PLAN.md
@@ -728,6 +728,60 @@ Each test case follows this format:
 
 ---
 
+### J. Relaunch — Reliability, Honesty & Contrast (v1.1)
+
+These cover the relaunch reliability spine, honest data, off-by-default weather, skip-vs-fallback semantics, light/dark contrast (P1/P2), the fork commit-back fallback, and the README visual proof.
+
+#### TC-REL-001 — Zero-key / fresh-clone build
+
+- Steps: Fresh clone with no `.env` and no secrets, run `npm install` then `npm run build`.
+- Expected: `dist/profile-chat.svg` renders with sensible defaults; no errors; no placeholder/garbage values; unconfigured integrations are skipped cleanly.
+
+#### TC-REL-002 — Status manifest classifications
+
+- Steps: Run a build; open `dist/status-manifest.json` and the GitHub Actions step summary.
+- Expected: Each source is classified live / skip / fallback / error; counts are accurate; 401/403/429 on a *configured* source surface as high-signal.
+
+#### TC-REL-003 — Alert open/close behavior
+
+- Steps: Cause a configured source to fail across a run, then restore it.
+- Expected: Exactly one GitHub issue auto-opens while failing and updates rather than spamming; it closes on recovery; no alert state is committed to the repo.
+
+#### TC-REL-004 — Skip vs fallback
+
+- Steps: Leave Spotify and GitHub-OAuth unconfigured; run a build.
+- Expected: They are reported as intentional **skip**, never fallback/error; no false alarm; defaults render.
+
+#### TC-REL-005 — Honest GitHub commit count
+
+- Steps: With a valid `PAT_GITHUB_OAUTH`, build and inspect the commits-last-year value.
+- Expected: Value is the real GitHub GraphQL contribution count (no fabricated estimate, no leading ~).
+
+#### TC-REL-006 — Weather off by default
+
+- Steps: With no AccuWeather key, build; then set `weather.enabled: true` + a key and rebuild.
+- Expected: Off by default → weather is skipped with defaults, no error. Enabled+key → live weather renders.
+
+#### TC-REL-007 — Light/dark contrast (P1 + P2)
+
+- Steps: View the SVG in light and dark for iOS, Android, and Discord (e.g. via the Configurator Mode toggle / OS color scheme).
+- Expected: Status text (Delivered/Read) is readable in both modes; visitor bubbles/text and visitor-side chart surfaces adapt (no white-on-white status, no glaring light slab in dark, no dark blob in light). Me-side unchanged.
+
+#### TC-REL-008 — Fork commit-back token fallback
+
+- Steps: On a fork without the owner PAT, enable Actions and let the build run.
+- Expected: The build auto-commits the SVG via `github.token` (no owner PAT required); the live badge updates.
+
+#### TC-REL-009 — Spotify-skip copy reads naturally
+
+- Steps: With Spotify unconfigured, inspect the rendered Spotify message.
+- Expected: Copy reads naturally (e.g. "I'm jamming to my coding playlist right now…"); no awkward "jamming to Not currently listening to music. right now".
+
+#### TC-REL-010 — README image/link check on GitHub
+
+- Steps: Open the rendered README on GitHub.
+- Expected: Hero badge, the six-image theme gallery (light + dark rows), Configurator screenshots, and the status-manifest image all load; all links resolve.
+
 ## Test Execution Log Template
 
 | Test Case ID | Status | Actual Result | Notes/Bug ID | Tester | Date |

--- a/data/chatData.json
+++ b/data/chatData.json
@@ -19,7 +19,7 @@
   {
     "id": "msg-spotify-response",
     "sender": "me",
-    "text": "I’m jamming to {spotifyTrack} right now—it really fuels my focus!"
+    "text": "I code to {spotifyTrack} — it really fuels my focus!"
   },
   {
     "id": "msg-3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "profilechatter",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "profilechatter",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "workspaces": [
         "configurator-ui"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "profilechatter",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "ProfileChatter – animated SVG chat bubbles for your GitHub README",
   "type": "module",
   "main": "src/main.js",
@@ -18,7 +18,7 @@
     "config:server:preview": "node configurator-ui/server/previewServer.js",
     "config:build": "npm run build --workspace configurator-ui",
     "test": "vitest",
-    "test:unit": "vitest run --dir tests/unit", 
+    "test:unit": "vitest run --dir tests/unit",
     "test:integration": "vitest run --dir tests/integration",
     "test:watch": "vitest watch",
     "coverage": "vitest run --coverage",

--- a/profileChatterConfig.json
+++ b/profileChatterConfig.json
@@ -60,7 +60,7 @@
     {
       "id": "msg-spotify-response",
       "sender": "me",
-      "text": "I’m jamming to {spotifyTrack} right now—it really fuels my focus!"
+      "text": "I code to {spotifyTrack} — it really fuels my focus!"
     },
     {
       "id": "msg-3",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -284,7 +284,7 @@ export const config = {
     GITHUB_PRIMARY_LANGUAGE: 'None',
     TWITTER_FOLLOWERS: '120',
     CODESTATS_XP: '0',
-    SPOTIFY_NOW_PLAYING: 'Not currently listening to music.',
+    SPOTIFY_NOW_PLAYING: 'my coding playlist',
   },
 
   layout: {

--- a/tests/unit/config/__tests__/spotify-default-copy.test.js
+++ b/tests/unit/config/__tests__/spotify-default-copy.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+
+import { config } from '../../../../src/config/config.js'
+
+/**
+ * When Spotify is unconfigured (intentional skip) or nothing is playing, the
+ * `{spotifyTrack}` placeholder falls back to `apiDefaults.SPOTIFY_NOW_PLAYING`.
+ * The default chat copy embeds it mid-sentence — "I code to {spotifyTrack} — it
+ * really fuels my focus!" — so the default must read as a noun phrase, not a
+ * standalone sentence (which produced the awkward "I code to Not currently
+ * listening to music. — it really fuels my focus!").
+ */
+describe('Spotify-skip default copy', () => {
+  const render = (v) => `I code to ${v} — it really fuels my focus!`
+
+  it('flows naturally in the default template when Spotify is unconfigured', () => {
+    const v = config.apiDefaults.SPOTIFY_NOW_PLAYING
+
+    // A mid-sentence phrase: lowercase-initial, no trailing period.
+    expect(v[0]).toBe(v[0].toLowerCase())
+    expect(v).not.toMatch(/\.$/)
+
+    const rendered = render(v)
+    // No sentence break (period) before the em-dash clause.
+    expect(rendered).not.toMatch(/\.\s+—/)
+    expect(rendered).not.toContain('I code to Not currently')
+  })
+})


### PR DESCRIPTION
@
## R5a — Release prep for v1.1.0

Release-prep slice for the 1.1.0 relaunch. **Tag and publish are deferred to R5b** (after manual QA + explicit approval). No git tag is created here.

### Changes
- **Version** 1.0.2 → **1.1.0** (`package.json` / `package-lock.json`, no tag)
- **CHANGELOG**: fold `Unreleased` into `[1.1.0]` — reliability spine, status manifest + alerting, honest GitHub count, weather off-by-default, skip-vs-fallback, P1/P2 contrast, R2b visuals, fork commit-back
- **MANUAL_QA_TEST_PLAN**: new section J (TC-REL-001..010) for the new reliability, honesty, and contrast surfaces
- **Spotify copy**: message made agnostic so it reads naturally whether or not a live track is playing.
  - Live track preserved: `I code to Song by Artist — it really fuels my focus!`
  - Idle/unconfigured: `I code to my coding playlist — it really fuels my focus!`
  - Focused test guards the default reading as a mid-sentence phrase.

### Scope (exactly these files)
- package.json
- package-lock.json
- CHANGELOG.md
- MANUAL_QA_TEST_PLAN.md
- src/config/config.js
- profileChatterConfig.json
- data/chatData.json
- tests/unit/config/__tests__/spotify-default-copy.test.js

### Notes
- `package.json` also drops one stray trailing space on the `test:unit` script line (harmless whitespace cleanup, flagged so it is not mistaken for hidden churn).
- No runtime/data-source behavior changes beyond the copy/template.
- `npm run verify` green locally: 506 tests, typecheck, lint, configurator build.
- Docs/config-heavy, so the path-filtered **ProfileChatter Build** check will not trigger; the required **verify** check will.
@